### PR TITLE
Add Warzone stats dashboard

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(curl:*)",
+      "Bash(python:*)",
+      "WebSearch",
+      "Bash(git add:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.env
+*.env
+debug*.html
+warzone-stats/data.json
+warzone-stats/game_ids.txt

--- a/warzone-stats/.env.example
+++ b/warzone-stats/.env.example
@@ -1,0 +1,5 @@
+# Warzone API Credentials
+# Copy this file to .env and fill in your details
+
+WARZONE_EMAIL=your@email.com
+WARZONE_PASSWORD=your_password_here

--- a/warzone-stats/build_standalone.py
+++ b/warzone-stats/build_standalone.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""
+Build a standalone HTML file with embedded CSS and data.
+"""
+
+import json
+from pathlib import Path
+
+def build_standalone():
+    # Read files
+    html_template = Path('index.html').read_text()
+    css = Path('style.css').read_text()
+    data = Path('data.json').read_text()
+
+    # Replace the external CSS link with embedded style
+    html_with_css = html_template.replace(
+        '<link rel="stylesheet" href="style.css">',
+        f'<style>{css}</style>'
+    )
+
+    # Replace the fetch() call with embedded data
+    html_with_data = html_with_css.replace(
+        'async function loadData() {\n            try {\n                const response = await fetch(\'data.json\');',
+        'async function loadData() {\n            try {\n                // Embedded data\n                const response = { ok: true, json: async () => EMBEDDED_DATA };'
+    )
+
+    # Add the data as a variable
+    html_with_data = html_with_data.replace(
+        '<script>',
+        f'<script>\n        const EMBEDDED_DATA = {data};\n'
+    )
+
+    # Write standalone file
+    output = Path('dashboard.html')
+    output.write_text(html_with_data)
+
+    print(f'Created standalone dashboard: {output}')
+    print(f'File size: {len(html_with_data) / 1024:.1f} KB')
+    print(f'\nYou can now open {output} directly in your browser!')
+
+if __name__ == '__main__':
+    build_standalone()

--- a/warzone-stats/build_standalone.py
+++ b/warzone-stats/build_standalone.py
@@ -30,13 +30,13 @@ def build_standalone():
         f'<script>\n        const EMBEDDED_DATA = {data};\n'
     )
 
-    # Write standalone file
-    output = Path('dashboard.html')
+    # Write standalone file (overwrite index.html to make it standalone)
+    output = Path('index.html')
     output.write_text(html_with_data)
 
-    print(f'Created standalone dashboard: {output}')
+    print(f'Updated index.html to standalone version (embedded CSS and data)')
     print(f'File size: {len(html_with_data) / 1024:.1f} KB')
-    print(f'\nYou can now open {output} directly in your browser!')
+    print(f'\nYou can now open index.html directly in your browser!')
 
 if __name__ == '__main__':
     build_standalone()

--- a/warzone-stats/dashboard.html
+++ b/warzone-stats/dashboard.html
@@ -1,4 +1,501 @@
-{
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Warzone Stats Dashboard</title>
+    <style>* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+:root {
+    --bg-primary: #1a1a2e;
+    --bg-secondary: #16213e;
+    --bg-card: #0f3460;
+    --text-primary: #eee;
+    --text-secondary: #aaa;
+    --accent: #e94560;
+    --accent-secondary: #0f3460;
+    --success: #4ecca3;
+    --warning: #ffc93c;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    line-height: 1.6;
+    min-height: 100vh;
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+/* Header */
+header {
+    text-align: center;
+    padding: 40px 0;
+    border-bottom: 1px solid var(--bg-card);
+    margin-bottom: 30px;
+}
+
+header h1 {
+    font-size: 2.5rem;
+    margin-bottom: 10px;
+    background: linear-gradient(135deg, var(--accent), var(--warning));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+}
+
+.last-updated {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    margin-top: 10px;
+}
+
+/* Stats Overview */
+.stats-overview {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 20px;
+    margin-bottom: 40px;
+}
+
+.stat-card {
+    background: var(--bg-card);
+    padding: 25px;
+    border-radius: 12px;
+    text-align: center;
+    transition: transform 0.2s;
+}
+
+.stat-card:hover {
+    transform: translateY(-3px);
+}
+
+.stat-value {
+    font-size: 2.5rem;
+    font-weight: bold;
+    color: var(--accent);
+}
+
+.stat-label {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    margin-top: 5px;
+}
+
+/* Sections */
+section {
+    margin-bottom: 40px;
+}
+
+section h2 {
+    font-size: 1.5rem;
+    margin-bottom: 20px;
+    padding-bottom: 10px;
+    border-bottom: 2px solid var(--accent);
+    display: inline-block;
+}
+
+.section-desc {
+    color: var(--text-secondary);
+    margin-bottom: 15px;
+}
+
+/* Leaderboard Table */
+table {
+    width: 100%;
+    border-collapse: collapse;
+    background: var(--bg-secondary);
+    border-radius: 12px;
+    overflow: hidden;
+}
+
+th, td {
+    padding: 15px;
+    text-align: left;
+}
+
+th {
+    background: var(--bg-card);
+    font-weight: 600;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    font-size: 0.8rem;
+    letter-spacing: 0.5px;
+}
+
+tr:not(:last-child) {
+    border-bottom: 1px solid var(--bg-card);
+}
+
+tr:hover {
+    background: rgba(233, 69, 96, 0.1);
+}
+
+.rank {
+    font-weight: bold;
+    color: var(--text-secondary);
+}
+
+.rank-1 .rank { color: gold; font-size: 1.2rem; }
+.rank-2 .rank { color: silver; font-size: 1.1rem; }
+.rank-3 .rank { color: #cd7f32; font-size: 1.05rem; }
+
+.player-name {
+    font-weight: 600;
+}
+
+.wins {
+    color: var(--success);
+    font-weight: bold;
+}
+
+.losses {
+    color: var(--accent);
+}
+
+/* Head-to-Head */
+.h2h-controls {
+    margin-bottom: 20px;
+}
+
+.h2h-controls select {
+    padding: 12px 20px;
+    font-size: 1rem;
+    border: none;
+    border-radius: 8px;
+    background: var(--bg-card);
+    color: var(--text-primary);
+    cursor: pointer;
+    min-width: 200px;
+}
+
+.h2h-table {
+    max-width: 500px;
+}
+
+.h2h-table .positive {
+    color: var(--success);
+    font-weight: bold;
+}
+
+.h2h-table .negative {
+    color: var(--accent);
+}
+
+.h2h-table .even {
+    color: var(--warning);
+}
+
+/* Filters */
+.filters {
+    display: flex;
+    gap: 15px;
+    margin-bottom: 20px;
+    flex-wrap: wrap;
+}
+
+.filters input,
+.filters select {
+    padding: 12px 15px;
+    font-size: 0.95rem;
+    border: none;
+    border-radius: 8px;
+    background: var(--bg-card);
+    color: var(--text-primary);
+    min-width: 150px;
+}
+
+.filters input {
+    flex: 1;
+    min-width: 200px;
+}
+
+.filters input::placeholder {
+    color: var(--text-secondary);
+}
+
+/* Games List */
+.games-container {
+    display: grid;
+    gap: 15px;
+}
+
+.game-card {
+    background: var(--bg-secondary);
+    border-radius: 12px;
+    padding: 20px;
+    border-left: 4px solid var(--accent);
+    transition: transform 0.2s;
+}
+
+.game-card:hover {
+    transform: translateX(5px);
+}
+
+.game-card.finished {
+    border-left-color: var(--success);
+}
+
+.game-card.in-progress {
+    border-left-color: var(--warning);
+}
+
+.game-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.game-name {
+    font-weight: 600;
+    font-size: 1.1rem;
+    color: var(--text-primary);
+    text-decoration: none;
+}
+
+.game-name:hover {
+    color: var(--accent);
+}
+
+.game-date {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+}
+
+.game-details {
+    display: flex;
+    gap: 15px;
+    margin-bottom: 12px;
+    font-size: 0.9rem;
+}
+
+.game-state {
+    padding: 3px 10px;
+    border-radius: 12px;
+    font-size: 0.8rem;
+    font-weight: 600;
+}
+
+.game-state.finished {
+    background: rgba(78, 204, 163, 0.2);
+    color: var(--success);
+}
+
+.game-state.in-progress {
+    background: rgba(255, 201, 60, 0.2);
+    color: var(--warning);
+}
+
+.game-turns {
+    color: var(--text-secondary);
+}
+
+.game-players {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 10px;
+}
+
+.player-tag {
+    padding: 4px 12px;
+    border-radius: 15px;
+    font-size: 0.85rem;
+    background: var(--bg-card);
+}
+
+.player-tag.won {
+    background: rgba(78, 204, 163, 0.3);
+    color: var(--success);
+}
+
+.player-tag.eliminated {
+    opacity: 0.7;
+}
+
+.game-winner {
+    color: var(--success);
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+/* Footer */
+footer {
+    text-align: center;
+    padding: 30px 0;
+    margin-top: 40px;
+    border-top: 1px solid var(--bg-card);
+    color: var(--text-secondary);
+}
+
+footer a {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+footer a:hover {
+    text-decoration: underline;
+}
+
+/* Error State */
+.error {
+    background: var(--bg-secondary);
+    padding: 40px;
+    border-radius: 12px;
+    text-align: center;
+    margin-top: 50px;
+}
+
+.error h2 {
+    color: var(--accent);
+    margin-bottom: 15px;
+}
+
+.error ol {
+    text-align: left;
+    max-width: 500px;
+    margin: 20px auto;
+}
+
+.error li {
+    margin-bottom: 10px;
+}
+
+.error code {
+    background: var(--bg-card);
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.9rem;
+}
+
+.error a {
+    color: var(--accent);
+}
+
+.no-results {
+    text-align: center;
+    color: var(--text-secondary);
+    padding: 40px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    header h1 {
+        font-size: 1.8rem;
+    }
+
+    .stats-overview {
+        grid-template-columns: repeat(3, 1fr);
+    }
+
+    th, td {
+        padding: 10px 8px;
+        font-size: 0.9rem;
+    }
+
+    .filters {
+        flex-direction: column;
+    }
+
+    .filters input,
+    .filters select {
+        width: 100%;
+    }
+}
+</style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>Warzone Stats Dashboard</h1>
+            <p class="subtitle">9 Years of Strategic Warfare</p>
+            <p class="last-updated" id="lastUpdated"></p>
+        </header>
+
+        <section class="stats-overview" id="statsOverview">
+            <div class="stat-card">
+                <div class="stat-value" id="totalGames">--</div>
+                <div class="stat-label">Total Games</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-value" id="totalPlayers">--</div>
+                <div class="stat-label">Players</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-value" id="avgTurns">--</div>
+                <div class="stat-label">Avg Turns/Game</div>
+            </div>
+        </section>
+
+        <section class="leaderboard">
+            <h2>Leaderboard</h2>
+            <table id="leaderboardTable">
+                <thead>
+                    <tr>
+                        <th>Rank</th>
+                        <th>Player</th>
+                        <th>Wins</th>
+                        <th>Losses</th>
+                        <th>Games</th>
+                        <th>Win Rate</th>
+                    </tr>
+                </thead>
+                <tbody id="leaderboardBody">
+                </tbody>
+            </table>
+        </section>
+
+        <section class="head-to-head">
+            <h2>Head-to-Head Records</h2>
+            <p class="section-desc">Select a player to see their record against others</p>
+            <div class="h2h-controls">
+                <select id="h2hPlayer">
+                    <option value="">Select a player...</option>
+                </select>
+            </div>
+            <div id="h2hResults" class="h2h-results"></div>
+        </section>
+
+        <section class="games-list">
+            <h2>Game History</h2>
+            <div class="filters">
+                <input type="text" id="searchGames" placeholder="Search games...">
+                <select id="filterPlayer">
+                    <option value="">All players</option>
+                </select>
+                <select id="filterState">
+                    <option value="">All states</option>
+                    <option value="Finished">Finished</option>
+                    <option value="Playing">In Progress</option>
+                </select>
+            </div>
+            <div id="gamesContainer" class="games-container"></div>
+        </section>
+
+        <footer>
+            <p>Data powered by <a href="https://www.warzone.com/wiki/API" target="_blank">Warzone API</a></p>
+        </footer>
+    </div>
+
+    <script>
+        const EMBEDDED_DATA = {
   "fetchedAt": "2025-11-30T15:57:51.422992Z",
   "totalGames": 137,
   "games": [
@@ -8091,4 +8588,250 @@
       "games": 1
     }
   ]
-}
+};
+
+        let gamesData = null;
+
+        async function loadData() {
+            try {
+                // Embedded data
+                const response = { ok: true, json: async () => EMBEDDED_DATA };
+                if (!response.ok) {
+                    throw new Error('Could not load data.json - run fetch-games.py first');
+                }
+                gamesData = await response.json();
+                renderDashboard();
+            } catch (error) {
+                document.querySelector('.container').innerHTML = `
+                    <div class="error">
+                        <h2>No Data Found</h2>
+                        <p>${error.message}</p>
+                        <p>To get started:</p>
+                        <ol>
+                            <li>Get your API token from <a href="https://www.warzone.com/API/GetAPIToken">warzone.com</a></li>
+                            <li>Create a file with your game IDs (one per line)</li>
+                            <li>Run: <code>python fetch-games.py -e your@email.com -t YOUR_TOKEN -g game_ids.txt</code></li>
+                        </ol>
+                    </div>
+                `;
+            }
+        }
+
+        function renderDashboard() {
+            // Update timestamp
+            const date = new Date(gamesData.fetchedAt);
+            document.getElementById('lastUpdated').textContent = `Last updated: ${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+
+            // Overview stats
+            document.getElementById('totalGames').textContent = gamesData.totalGames;
+            document.getElementById('totalPlayers').textContent = gamesData.playerStats.length;
+
+            const finishedGames = gamesData.games.filter(g => g.state === 'Finished');
+            const avgTurns = finishedGames.length > 0
+                ? Math.round(finishedGames.reduce((sum, g) => sum + parseInt(g.numberOfTurns || 0), 0) / finishedGames.length)
+                : 0;
+            document.getElementById('avgTurns').textContent = avgTurns;
+
+            // Update total games to show finished count
+            document.getElementById('totalGames').textContent = finishedGames.length;
+            const inProgress = gamesData.games.filter(g => g.state !== 'Finished').length;
+            if (inProgress > 0) {
+                document.getElementById('totalGames').textContent += ` (${inProgress} in progress)`;
+            }
+
+            // Leaderboard
+            renderLeaderboard();
+
+            // Populate dropdowns
+            populatePlayerDropdowns();
+
+            // Games list
+            renderGames(gamesData.games);
+
+            // Event listeners
+            setupEventListeners();
+        }
+
+        function renderLeaderboard() {
+            const tbody = document.getElementById('leaderboardBody');
+            const sorted = [...gamesData.playerStats].sort((a, b) => {
+                // Sort by wins, then by win rate
+                if (b.wins !== a.wins) return b.wins - a.wins;
+                const aRate = a.games > 0 ? a.wins / a.games : 0;
+                const bRate = b.games > 0 ? b.wins / b.games : 0;
+                return bRate - aRate;
+            });
+
+            tbody.innerHTML = sorted.map((player, idx) => {
+                const winRate = player.games > 0 ? (player.wins / player.games * 100).toFixed(1) : 0;
+                const rankClass = idx < 3 ? `rank-${idx + 1}` : '';
+                return `
+                    <tr class="${rankClass}">
+                        <td class="rank">${idx + 1}</td>
+                        <td class="player-name">${escapeHtml(player.name)}</td>
+                        <td class="wins">${player.wins}</td>
+                        <td class="losses">${player.losses}</td>
+                        <td>${player.games}</td>
+                        <td>${winRate}%</td>
+                    </tr>
+                `;
+            }).join('');
+        }
+
+        function populatePlayerDropdowns() {
+            const players = gamesData.playerStats.map(p => p.name).sort();
+            const options = players.map(p => `<option value="${escapeHtml(p)}">${escapeHtml(p)}</option>`).join('');
+
+            document.getElementById('h2hPlayer').innerHTML = '<option value="">Select a player...</option>' + options;
+            document.getElementById('filterPlayer').innerHTML = '<option value="">All players</option>' + options;
+        }
+
+        function renderGames(games) {
+            const container = document.getElementById('gamesContainer');
+            const sorted = [...games].sort((a, b) => {
+                // Sort by date, newest first
+                if (a.created && b.created) {
+                    return new Date(b.created) - new Date(a.created);
+                }
+                return b.id - a.id;
+            });
+
+            if (sorted.length === 0) {
+                container.innerHTML = '<p class="no-results">No games found</p>';
+                return;
+            }
+
+            container.innerHTML = sorted.map(game => {
+                const date = game.created ? new Date(game.created).toLocaleDateString() : 'Unknown date';
+                const winners = game.winners.length > 0 ? game.winners.join(', ') : 'N/A';
+                const stateClass = game.state === 'Finished' ? 'finished' : 'in-progress';
+
+                const playersList = game.players.map(p => {
+                    const stateIcon = p.state === 'Won' ? ' &#x1F3C6;' : '';
+                    return `<span class="player-tag ${p.state.toLowerCase()}">${escapeHtml(p.name)}${stateIcon}</span>`;
+                }).join(' ');
+
+                return `
+                    <div class="game-card ${stateClass}">
+                        <div class="game-header">
+                            <a href="https://www.warzone.com/MultiPlayer?GameID=${game.id}" target="_blank" class="game-name">${escapeHtml(game.name)}</a>
+                            <span class="game-date">${date}</span>
+                        </div>
+                        <div class="game-details">
+                            <span class="game-state ${stateClass}">${game.state}</span>
+                            <span class="game-turns">${game.numberOfTurns} turns</span>
+                        </div>
+                        <div class="game-players">${playersList}</div>
+                        ${game.winners.length > 0 ? `<div class="game-winner">Winner: ${escapeHtml(winners)}</div>` : ''}
+                    </div>
+                `;
+            }).join('');
+        }
+
+        function calculateH2H(playerName) {
+            const h2h = {};
+
+            gamesData.games.filter(g => g.state === 'Finished').forEach(game => {
+                const playerInGame = game.players.find(p => p.name.toLowerCase() === playerName.toLowerCase());
+                if (!playerInGame) return;
+
+                const playerWon = playerInGame.state === 'Won';
+
+                game.players.forEach(opponent => {
+                    if (opponent.name.toLowerCase() === playerName.toLowerCase()) return;
+
+                    if (!h2h[opponent.name]) {
+                        h2h[opponent.name] = { wins: 0, losses: 0, games: 0 };
+                    }
+
+                    h2h[opponent.name].games++;
+                    if (playerWon) {
+                        h2h[opponent.name].wins++;
+                    } else if (opponent.state === 'Won') {
+                        h2h[opponent.name].losses++;
+                    }
+                });
+            });
+
+            return h2h;
+        }
+
+        function renderH2H(playerName) {
+            const container = document.getElementById('h2hResults');
+
+            if (!playerName) {
+                container.innerHTML = '';
+                return;
+            }
+
+            const h2h = calculateH2H(playerName);
+            const entries = Object.entries(h2h).sort((a, b) => b[1].games - a[1].games);
+
+            if (entries.length === 0) {
+                container.innerHTML = '<p class="no-results">No head-to-head data found</p>';
+                return;
+            }
+
+            container.innerHTML = `
+                <table class="h2h-table">
+                    <thead>
+                        <tr>
+                            <th>Opponent</th>
+                            <th>Record</th>
+                            <th>Games</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        ${entries.map(([opponent, record]) => {
+                            const recordClass = record.wins > record.losses ? 'positive' : record.wins < record.losses ? 'negative' : 'even';
+                            return `
+                                <tr>
+                                    <td>${escapeHtml(opponent)}</td>
+                                    <td class="${recordClass}">${record.wins} - ${record.losses}</td>
+                                    <td>${record.games}</td>
+                                </tr>
+                            `;
+                        }).join('')}
+                    </tbody>
+                </table>
+            `;
+        }
+
+        function setupEventListeners() {
+            // Head-to-head selector
+            document.getElementById('h2hPlayer').addEventListener('change', (e) => {
+                renderH2H(e.target.value);
+            });
+
+            // Game filters
+            const filterGames = () => {
+                const search = document.getElementById('searchGames').value.toLowerCase();
+                const player = document.getElementById('filterPlayer').value.toLowerCase();
+                const state = document.getElementById('filterState').value;
+
+                const filtered = gamesData.games.filter(game => {
+                    if (search && !game.name.toLowerCase().includes(search)) return false;
+                    if (player && !game.players.some(p => p.name.toLowerCase() === player)) return false;
+                    if (state && game.state !== state) return false;
+                    return true;
+                });
+
+                renderGames(filtered);
+            };
+
+            document.getElementById('searchGames').addEventListener('input', filterGames);
+            document.getElementById('filterPlayer').addEventListener('change', filterGames);
+            document.getElementById('filterState').addEventListener('change', filterGames);
+        }
+
+        function escapeHtml(text) {
+            const div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
+        }
+
+        // Load data on page load
+        loadData();
+    </script>
+</body>
+</html>

--- a/warzone-stats/data.json
+++ b/warzone-stats/data.json
@@ -1,0 +1,127 @@
+{
+  "fetchedAt": "2024-01-15T12:00:00Z",
+  "totalGames": 8,
+  "games": [
+    {
+      "id": 12345678,
+      "name": "Family Game Night #127",
+      "state": "Finished",
+      "created": "2024-01-10T20:00:00Z",
+      "numberOfTurns": 42,
+      "players": [
+        {"id": "1001", "name": "Player1", "state": "Won", "team": "None"},
+        {"id": "1002", "name": "Player2", "state": "Eliminated", "team": "None"},
+        {"id": "1003", "name": "Player3", "state": "Eliminated", "team": "None"},
+        {"id": "1004", "name": "Player4", "state": "Eliminated", "team": "None"}
+      ],
+      "winners": ["Player1"],
+      "templateId": 999
+    },
+    {
+      "id": 12345677,
+      "name": "Weekend Warriors",
+      "state": "Finished",
+      "created": "2024-01-05T18:30:00Z",
+      "numberOfTurns": 38,
+      "players": [
+        {"id": "1001", "name": "Player1", "state": "Eliminated", "team": "None"},
+        {"id": "1002", "name": "Player2", "state": "Won", "team": "None"},
+        {"id": "1003", "name": "Player3", "state": "Eliminated", "team": "None"}
+      ],
+      "winners": ["Player2"],
+      "templateId": 999
+    },
+    {
+      "id": 12345676,
+      "name": "New Year Battle",
+      "state": "Finished",
+      "created": "2024-01-01T00:15:00Z",
+      "numberOfTurns": 55,
+      "players": [
+        {"id": "1001", "name": "Player1", "state": "Eliminated", "team": "None"},
+        {"id": "1002", "name": "Player2", "state": "Eliminated", "team": "None"},
+        {"id": "1003", "name": "Player3", "state": "Won", "team": "None"},
+        {"id": "1004", "name": "Player4", "state": "Eliminated", "team": "None"}
+      ],
+      "winners": ["Player3"],
+      "templateId": 999
+    },
+    {
+      "id": 12345675,
+      "name": "Holiday Showdown",
+      "state": "Finished",
+      "created": "2023-12-25T14:00:00Z",
+      "numberOfTurns": 29,
+      "players": [
+        {"id": "1001", "name": "Player1", "state": "Won", "team": "None"},
+        {"id": "1002", "name": "Player2", "state": "Eliminated", "team": "None"},
+        {"id": "1004", "name": "Player4", "state": "Eliminated", "team": "None"}
+      ],
+      "winners": ["Player1"],
+      "templateId": 999
+    },
+    {
+      "id": 12345674,
+      "name": "Strategy Session",
+      "state": "Finished",
+      "created": "2023-12-20T19:00:00Z",
+      "numberOfTurns": 47,
+      "players": [
+        {"id": "1001", "name": "Player1", "state": "Eliminated", "team": "None"},
+        {"id": "1002", "name": "Player2", "state": "Eliminated", "team": "None"},
+        {"id": "1003", "name": "Player3", "state": "Eliminated", "team": "None"},
+        {"id": "1004", "name": "Player4", "state": "Won", "team": "None"}
+      ],
+      "winners": ["Player4"],
+      "templateId": 999
+    },
+    {
+      "id": 12345673,
+      "name": "Quick Match",
+      "state": "Finished",
+      "created": "2023-12-15T21:00:00Z",
+      "numberOfTurns": 18,
+      "players": [
+        {"id": "1002", "name": "Player2", "state": "Won", "team": "None"},
+        {"id": "1003", "name": "Player3", "state": "Eliminated", "team": "None"}
+      ],
+      "winners": ["Player2"],
+      "templateId": 999
+    },
+    {
+      "id": 12345672,
+      "name": "Epic Battle Royale",
+      "state": "Finished",
+      "created": "2023-12-10T17:30:00Z",
+      "numberOfTurns": 63,
+      "players": [
+        {"id": "1001", "name": "Player1", "state": "Won", "team": "None"},
+        {"id": "1002", "name": "Player2", "state": "Eliminated", "team": "None"},
+        {"id": "1003", "name": "Player3", "state": "Eliminated", "team": "None"},
+        {"id": "1004", "name": "Player4", "state": "Eliminated", "team": "None"}
+      ],
+      "winners": ["Player1"],
+      "templateId": 999
+    },
+    {
+      "id": 12345671,
+      "name": "Current Game",
+      "state": "Playing",
+      "created": "2024-01-14T10:00:00Z",
+      "numberOfTurns": 12,
+      "players": [
+        {"id": "1001", "name": "Player1", "state": "Playing", "team": "None"},
+        {"id": "1002", "name": "Player2", "state": "Playing", "team": "None"},
+        {"id": "1003", "name": "Player3", "state": "Playing", "team": "None"}
+      ],
+      "winners": [],
+      "templateId": 999
+    }
+  ],
+  "playerStats": [
+    {"name": "Player1", "wins": 3, "losses": 3, "games": 6},
+    {"name": "Player2", "wins": 2, "losses": 4, "games": 7},
+    {"name": "Player3", "wins": 1, "losses": 5, "games": 7},
+    {"name": "Player4", "wins": 1, "losses": 3, "games": 4}
+  ]
+}

--- a/warzone-stats/data.json
+++ b/warzone-stats/data.json
@@ -1,6 +1,6 @@
 {
-  "fetchedAt": "2025-11-30T15:57:51.422992Z",
-  "totalGames": 137,
+  "fetchedAt": "2025-11-30T17:43:51.575748Z",
+  "totalGames": 134,
   "games": [
     {
       "id": "12575368",
@@ -2264,37 +2264,6 @@
       "templateId": null
     },
     {
-      "id": "13709736",
-      "name": "Rematch: starvation in Rome, army cap 2x income",
-      "state": "Finished",
-      "created": "6/25/2017 00:11:10",
-      "numberOfTurns": "16",
-      "players": [
-        {
-          "id": "3776911513",
-          "name": "dnathe4th",
-          "state": "SurrenderAccepted",
-          "team": "None"
-        },
-        {
-          "id": "3976572255",
-          "name": "Jtaugelli",
-          "state": "Won",
-          "team": "None"
-        },
-        {
-          "id": "3976915175",
-          "name": "ajnard",
-          "state": "RemovedByHost",
-          "team": "None"
-        }
-      ],
-      "winners": [
-        "Jtaugelli"
-      ],
-      "templateId": "1052462"
-    },
-    {
       "id": "26678961",
       "name": "dom's warlight game",
       "state": "Finished",
@@ -2930,65 +2899,6 @@
         "dnathe4th"
       ],
       "templateId": null
-    },
-    {
-      "id": "13299682",
-      "name": "dnathe4th's WarLight game",
-      "state": "Finished",
-      "created": "4/14/2017 21:15:37",
-      "numberOfTurns": "19",
-      "players": [
-        {
-          "id": "3776911513",
-          "name": "dnathe4th",
-          "state": "SurrenderAccepted",
-          "team": "None"
-        },
-        {
-          "id": "3976915175",
-          "name": "ajnard",
-          "state": "SurrenderAccepted",
-          "team": "None"
-        },
-        {
-          "id": "-1000",
-          "name": "AI 1",
-          "state": "EndedByVote",
-          "team": "None"
-        },
-        {
-          "id": "-1001",
-          "name": "AI 2",
-          "state": "EndedByVote",
-          "team": "None"
-        },
-        {
-          "id": "-1002",
-          "name": "AI 3",
-          "state": "EndedByVote",
-          "team": "None"
-        },
-        {
-          "id": "-1003",
-          "name": "AI 4",
-          "state": "EndedByVote",
-          "team": "None"
-        },
-        {
-          "id": "-1004",
-          "name": "AI 5",
-          "state": "EndedByVote",
-          "team": "None"
-        },
-        {
-          "id": "-1005",
-          "name": "AI 6",
-          "state": "Eliminated",
-          "team": "None"
-        }
-      ],
-      "winners": [],
-      "templateId": "1022054"
     },
     {
       "id": "13202917",
@@ -4139,31 +4049,6 @@
       "winners": [
         "dnathe4th",
         "tedwaldo"
-      ],
-      "templateId": null
-    },
-    {
-      "id": "15855604",
-      "name": "Auto Imperium Romanum LD 1v1 (light fog)",
-      "state": "Finished",
-      "created": "6/18/2018 06:15:11",
-      "numberOfTurns": "19",
-      "players": [
-        {
-          "id": "3776911513",
-          "name": "dnathe4th",
-          "state": "Won",
-          "team": "None"
-        },
-        {
-          "id": "3976915175",
-          "name": "ajnard",
-          "state": "Booted",
-          "team": "None"
-        }
-      ],
-      "winners": [
-        "dnathe4th"
       ],
       "templateId": null
     },
@@ -7990,15 +7875,15 @@
   "playerStats": [
     {
       "name": "dnathe4th",
-      "wins": 22,
-      "losses": 112,
-      "games": 136
+      "wins": 21,
+      "losses": 110,
+      "games": 133
     },
     {
       "name": "Jtaugelli",
-      "wins": 5,
+      "wins": 4,
       "losses": 57,
-      "games": 67
+      "games": 66
     },
     {
       "name": "Dauntless",
@@ -8009,8 +7894,8 @@
     {
       "name": "ajnard",
       "wins": 23,
-      "losses": 109,
-      "games": 136
+      "losses": 107,
+      "games": 133
     },
     {
       "name": "13litz_krieg",
@@ -8052,37 +7937,7 @@
       "name": "AI 1",
       "wins": 1,
       "losses": 2,
-      "games": 5
-    },
-    {
-      "name": "AI 2",
-      "wins": 0,
-      "losses": 0,
-      "games": 1
-    },
-    {
-      "name": "AI 3",
-      "wins": 0,
-      "losses": 0,
-      "games": 1
-    },
-    {
-      "name": "AI 4",
-      "wins": 0,
-      "losses": 0,
-      "games": 1
-    },
-    {
-      "name": "AI 5",
-      "wins": 0,
-      "losses": 0,
-      "games": 1
-    },
-    {
-      "name": "AI 6",
-      "wins": 0,
-      "losses": 1,
-      "games": 1
+      "games": 4
     },
     {
       "name": "",

--- a/warzone-stats/fetch-games.py
+++ b/warzone-stats/fetch-games.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""
+Warzone Game Data Fetcher
+
+Fetches game data from the Warzone API and outputs a JSON file
+for use with the static dashboard.
+
+Usage:
+    # Auto-discover all your games (login with email/password):
+    python fetch-games.py --email your@email.com --password YOUR_PASSWORD
+
+    # Or provide game IDs manually (with API token):
+    python fetch-games.py --email your@email.com --token YOUR_API_TOKEN --games game_ids.txt
+
+    # Filter to only games with specific players:
+    python fetch-games.py --email your@email.com --password YOUR_PASSWORD --filter-players "Player1,Player2,Player3"
+
+Get your API token at: https://www.warzone.com/API/GetAPIToken (while logged in)
+"""
+
+import argparse
+import json
+import re
+import requests
+import time
+import sys
+from pathlib import Path
+from datetime import datetime
+from urllib.parse import urljoin
+
+
+API_BASE = "https://www.warzone.com"
+RATE_LIMIT_DELAY = 0.5  # seconds between requests
+
+
+def get_api_token(email: str, password: str) -> str | None:
+    """Get API token using email and password."""
+    print("Getting API token...")
+    try:
+        response = requests.post(
+            f"{API_BASE}/API/GetAPIToken",
+            data=f"Email={email}&Password={password}",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=30
+        )
+        if response.status_code == 200:
+            data = response.json()
+            if "APIToken" in data:
+                print("Got API token successfully")
+                return data["APIToken"]
+            else:
+                print(f"Error getting token: {data}")
+                return None
+    except Exception as e:
+        print(f"Error getting API token: {e}")
+        return None
+
+
+def create_session(email: str, password: str) -> requests.Session | None:
+    """Create an authenticated session for web scraping."""
+    print("Logging in to Warzone...")
+    session = requests.Session()
+
+    try:
+        # First, get the login page to get any CSRF tokens
+        login_page = session.get(f"{API_BASE}/SignIn", timeout=30)
+
+        # Post login credentials
+        response = session.post(
+            f"{API_BASE}/SignIn",
+            data={
+                "Email": email,
+                "Password": password,
+            },
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Referer": f"{API_BASE}/SignIn",
+            },
+            allow_redirects=True,
+            timeout=30
+        )
+
+        # Check if login was successful by looking for signs of authentication
+        if "SignOut" in response.text or "MyGames" in response.text:
+            print("Login successful!")
+            return session
+        else:
+            print("Login may have failed - checking anyway...")
+            return session
+
+    except Exception as e:
+        print(f"Error during login: {e}")
+        return None
+
+
+def scrape_game_ids(session: requests.Session, max_pages: int = 100) -> list[str]:
+    """Scrape all game IDs from the My Games page."""
+    print("Scraping game IDs from My Games page...")
+    all_game_ids = set()
+    page = 0
+
+    while page < max_pages:
+        url = f"{API_BASE}/MultiPlayer?MyGames=1&Offset={page * 50}"
+        print(f"  Fetching page {page + 1} (offset {page * 50})...", end=" ")
+
+        try:
+            response = session.get(url, timeout=30)
+            if response.status_code != 200:
+                print(f"HTTP {response.status_code}")
+                break
+
+            # Find all game IDs in the page
+            game_ids = re.findall(r'GameID=(\d+)', response.text)
+            unique_ids = set(game_ids)
+
+            if not unique_ids:
+                print("No more games found")
+                break
+
+            new_ids = unique_ids - all_game_ids
+            if not new_ids:
+                print("No new games (reached end)")
+                break
+
+            all_game_ids.update(unique_ids)
+            print(f"Found {len(new_ids)} new games (total: {len(all_game_ids)})")
+
+            page += 1
+            time.sleep(RATE_LIMIT_DELAY)
+
+        except Exception as e:
+            print(f"Error: {e}")
+            break
+
+    return list(all_game_ids)
+
+
+def fetch_game(game_id: str, email: str, token: str) -> dict | None:
+    """Fetch a single game's data from the Warzone API."""
+    data = f"Email={email}&APIToken={token}"
+
+    try:
+        response = requests.post(
+            f"{API_BASE}/API/GameFeed?GameID={game_id}&GetSettings=true",
+            data=data,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=30
+        )
+
+        if response.status_code == 200:
+            return response.json()
+        else:
+            print(f"  Error fetching game {game_id}: HTTP {response.status_code}")
+            return None
+    except requests.RequestException as e:
+        print(f"  Error fetching game {game_id}: {e}")
+        return None
+
+
+def parse_game_data(raw: dict) -> dict | None:
+    """Parse raw API response into our simplified format."""
+    if "error" in raw:
+        return None
+
+    # Extract player info
+    players = []
+    for p in raw.get("players", []):
+        player = {
+            "id": p.get("id"),
+            "name": p.get("name", "Unknown"),
+            "state": p.get("state"),  # Won, Eliminated, Playing, etc.
+            "team": p.get("team", "None"),
+        }
+        players.append(player)
+
+    # Determine winner(s)
+    winners = [p["name"] for p in players if p["state"] == "Won"]
+
+    return {
+        "id": raw.get("id"),
+        "name": raw.get("name", "Unnamed Game"),
+        "state": raw.get("state"),  # Finished, Playing, etc.
+        "created": raw.get("created"),
+        "numberOfTurns": raw.get("numberOfTurns", 0),
+        "players": players,
+        "winners": winners,
+        "templateId": raw.get("templateID"),
+    }
+
+
+def load_game_ids(source: str) -> list[str]:
+    """Load game IDs from a file or comma-separated string."""
+    path = Path(source)
+    if path.exists():
+        content = path.read_text()
+    else:
+        content = source
+
+    # Handle comma-separated, newline-separated, or mixed
+    ids = []
+    for line in content.replace(",", "\n").split("\n"):
+        game_id = line.strip()
+        if game_id and game_id.isdigit():
+            ids.append(game_id)
+
+    return ids
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Fetch Warzone game data for the stats dashboard"
+    )
+    parser.add_argument(
+        "--email", "-e",
+        required=True,
+        help="Your Warzone account email"
+    )
+    parser.add_argument(
+        "--password", "-p",
+        help="Your Warzone account password (for auto-discovery of game IDs)"
+    )
+    parser.add_argument(
+        "--token", "-t",
+        help="Your Warzone API token (alternative to password)"
+    )
+    parser.add_argument(
+        "--games", "-g",
+        help="File containing game IDs (one per line) or comma-separated list. If not provided, will auto-discover."
+    )
+    parser.add_argument(
+        "--output", "-o",
+        default="data.json",
+        help="Output JSON file (default: data.json)"
+    )
+    parser.add_argument(
+        "--filter-players", "-f",
+        help="Comma-separated list of player names to filter by (only include games with ANY of these players)"
+    )
+    parser.add_argument(
+        "--filter-all-players",
+        help="Comma-separated list of player names - only include games with ALL of these players"
+    )
+    parser.add_argument(
+        "--max-games",
+        type=int,
+        default=0,
+        help="Maximum number of games to fetch (0 = unlimited)"
+    )
+
+    args = parser.parse_args()
+
+    # Validate arguments
+    if not args.password and not args.token:
+        print("Error: You must provide either --password or --token")
+        sys.exit(1)
+
+    # Get API token
+    api_token = args.token
+    if not api_token and args.password:
+        api_token = get_api_token(args.email, args.password)
+        if not api_token:
+            print("Failed to get API token. Check your credentials.")
+            sys.exit(1)
+
+    # Get game IDs
+    game_ids = []
+    if args.games:
+        game_ids = load_game_ids(args.games)
+        print(f"Loaded {len(game_ids)} game IDs from input")
+    else:
+        # Auto-discover games by scraping
+        if not args.password:
+            print("Error: --password is required for auto-discovery (or provide --games)")
+            sys.exit(1)
+
+        session = create_session(args.email, args.password)
+        if not session:
+            print("Failed to create session")
+            sys.exit(1)
+
+        game_ids = scrape_game_ids(session)
+        print(f"\nDiscovered {len(game_ids)} total games")
+
+    if not game_ids:
+        print("No game IDs found!")
+        sys.exit(1)
+
+    # Apply max games limit
+    if args.max_games > 0:
+        game_ids = game_ids[:args.max_games]
+        print(f"Limited to {len(game_ids)} games")
+
+    # Optional player filters
+    filter_any_players = None
+    filter_all_players = None
+
+    if args.filter_players:
+        filter_any_players = set(name.strip().lower() for name in args.filter_players.split(","))
+        print(f"Filtering for games with ANY of: {filter_any_players}")
+
+    if args.filter_all_players:
+        filter_all_players = set(name.strip().lower() for name in args.filter_all_players.split(","))
+        print(f"Filtering for games with ALL of: {filter_all_players}")
+
+    # Fetch all games
+    print(f"\nFetching {len(game_ids)} games from API...")
+    games = []
+    errors = 0
+    skipped = 0
+
+    for i, game_id in enumerate(game_ids, 1):
+        print(f"[{i}/{len(game_ids)}] Game {game_id}...", end=" ")
+
+        raw = fetch_game(game_id, args.email, api_token)
+        if raw is None:
+            errors += 1
+            continue
+
+        parsed = parse_game_data(raw)
+        if parsed is None:
+            print("Parse error")
+            errors += 1
+            continue
+
+        # Apply player filters
+        game_players = set(p["name"].lower() for p in parsed["players"])
+
+        if filter_any_players:
+            if not filter_any_players.intersection(game_players):
+                print("Skipped (no matching players)")
+                skipped += 1
+                continue
+
+        if filter_all_players:
+            if not filter_all_players.issubset(game_players):
+                print("Skipped (missing required players)")
+                skipped += 1
+                continue
+
+        games.append(parsed)
+        print(f"OK - {parsed['name'][:40]}")
+
+        time.sleep(RATE_LIMIT_DELAY)
+
+    # Calculate aggregate stats
+    print("\nCalculating stats...")
+    player_stats = {}
+    for game in games:
+        if game["state"] != "Finished":
+            continue
+
+        for player in game["players"]:
+            name = player["name"]
+            if name not in player_stats:
+                player_stats[name] = {
+                    "name": name,
+                    "wins": 0,
+                    "losses": 0,
+                    "games": 0,
+                }
+
+            player_stats[name]["games"] += 1
+            if player["state"] == "Won":
+                player_stats[name]["wins"] += 1
+            elif player["state"] in ("Eliminated", "SurrenderAccepted", "Booted"):
+                player_stats[name]["losses"] += 1
+
+    # Build output
+    output = {
+        "fetchedAt": datetime.utcnow().isoformat() + "Z",
+        "totalGames": len(games),
+        "games": games,
+        "playerStats": list(player_stats.values()),
+    }
+
+    # Write output
+    output_path = Path(args.output)
+    output_path.write_text(json.dumps(output, indent=2))
+
+    print(f"\n{'='*50}")
+    print(f"Done! Fetched {len(games)} games ({errors} errors, {skipped} skipped)")
+    print(f"Output written to: {output_path}")
+
+    # Print quick summary
+    if player_stats:
+        print(f"\n{'='*50}")
+        print("LEADERBOARD")
+        print(f"{'='*50}")
+        for stat in sorted(player_stats.values(), key=lambda x: x["wins"], reverse=True)[:10]:
+            win_rate = (stat["wins"] / stat["games"] * 100) if stat["games"] > 0 else 0
+            print(f"  {stat['name']}: {stat['wins']}W / {stat['losses']}L ({win_rate:.1f}%)")
+
+
+if __name__ == "__main__":
+    main()

--- a/warzone-stats/fetch-games.py
+++ b/warzone-stats/fetch-games.py
@@ -20,8 +20,10 @@ Get your API token at: https://www.warzone.com/API/GetAPIToken (while logged in)
 
 import argparse
 import json
+import os
 import re
 import requests
+import struct
 import time
 import sys
 from pathlib import Path
@@ -31,6 +33,18 @@ from urllib.parse import urljoin
 
 API_BASE = "https://www.warzone.com"
 RATE_LIMIT_DELAY = 0.5  # seconds between requests
+
+
+def load_env():
+    """Load environment variables from .env file if it exists."""
+    env_path = Path(__file__).parent / ".env"
+    if env_path.exists():
+        with open(env_path) as f:
+            for line in f:
+                line = line.strip()
+                if line and not line.startswith("#"):
+                    key, value = line.split("=", 1)
+                    os.environ[key.strip()] = value.strip()
 
 
 def get_api_token(email: str, password: str) -> str | None:
@@ -56,80 +70,307 @@ def get_api_token(email: str, password: str) -> str | None:
         return None
 
 
-def create_session(email: str, password: str) -> requests.Session | None:
+def create_session(email: str, password: str, debug: bool = False) -> requests.Session | None:
     """Create an authenticated session for web scraping."""
     print("Logging in to Warzone...")
     session = requests.Session()
 
     try:
-        # First, get the login page to get any CSRF tokens
+        # First, get the login page to examine the form
+        print("  Fetching login page...")
         login_page = session.get(f"{API_BASE}/SignIn", timeout=30)
 
+        if debug:
+            with open("debug_login_page.html", "w", encoding="utf-8") as f:
+                f.write(login_page.text)
+            print(f"  Debug: Saved login page to debug_login_page.html")
+
+        # Try to find the form action and any hidden fields
+        form_action = "/SignIn"  # Default
+        hidden_fields = {}
+
+        # Look for hidden input fields (CSRF tokens, etc.)
+        import re
+        hidden_inputs = re.findall(r'<input[^>]*type=["\']hidden["\'][^>]*>', login_page.text, re.IGNORECASE)
+        for hidden in hidden_inputs:
+            name_match = re.search(r'name=["\']([^"\']+)["\']', hidden)
+            value_match = re.search(r'value=["\']([^"\']*)["\']', hidden)
+            if name_match and value_match:
+                hidden_fields[name_match.group(1)] = value_match.group(1)
+                if debug:
+                    print(f"  Debug: Found hidden field: {name_match.group(1)} = {value_match.group(1)[:20]}...")
+
+        # Build login data with hidden fields + credentials
+        login_data = {
+            **hidden_fields,
+            "email": email,
+            "password": password,
+        }
+
         # Post login credentials
+        print("  Submitting login form...")
         response = session.post(
-            f"{API_BASE}/SignIn",
-            data={
-                "Email": email,
-                "Password": password,
-            },
+            f"{API_BASE}{form_action}",
+            data=login_data,
             headers={
                 "Content-Type": "application/x-www-form-urlencoded",
                 "Referer": f"{API_BASE}/SignIn",
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
             },
             allow_redirects=True,
             timeout=30
         )
 
-        # Check if login was successful by looking for signs of authentication
-        if "SignOut" in response.text or "MyGames" in response.text:
+        if debug:
+            with open("debug_login_response.html", "w", encoding="utf-8") as f:
+                f.write(response.text)
+            print(f"  Debug: Saved login response to debug_login_response.html")
+            print(f"  Debug: Response URL: {response.url}")
+            print(f"  Debug: Response status: {response.status_code}")
+
+        # Check if login was successful
+        if response.status_code == 405:
+            print("ERROR: Login endpoint returned 405 Method Not Allowed")
+            print("This suggests Warzone's login may use JavaScript or a different endpoint.")
+            if debug:
+                print("Check debug_login_page.html to see the actual login form structure")
+            return None
+        elif "SignOut" in response.text or "MyGames" in response.text:
             print("Login successful!")
             return session
+        elif "error" in response.text.lower() or "incorrect" in response.text.lower():
+            print("ERROR: Login failed - incorrect credentials or account issue")
+            if debug:
+                print("Check debug_login_response.html for details")
+            return None
         else:
-            print("Login may have failed - checking anyway...")
+            print("WARNING: Login may have failed - unable to verify authentication")
+            if debug:
+                print("Check debug_login_response.html to see what was returned")
             return session
 
     except Exception as e:
         print(f"Error during login: {e}")
+        import traceback
+        if debug:
+            traceback.print_exc()
         return None
 
 
-def scrape_game_ids(session: requests.Session, max_pages: int = 100) -> list[str]:
-    """Scrape all game IDs from the My Games page."""
-    print("Scraping game IDs from My Games page...")
+def authenticate_and_get_session(email: str, password: str, debug: bool = False) -> requests.Session | None:
+    """Authenticate with Warzone and return a session with valid cookies."""
+    print("Authenticating with Warzone...")
+    session = requests.Session()
+
+    # Set headers to mimic a real browser
+    session.headers.update({
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+        'Accept-Language': 'en-US,en;q=0.5',
+        'Accept-Encoding': 'gzip, deflate, br',
+        'DNT': '1',
+        'Connection': 'keep-alive',
+        'Upgrade-Insecure-Requests': '1',
+    })
+
+    try:
+        # First, visit the main page to get initial cookies
+        print("  Getting initial session...")
+        home_response = session.get(f"{API_BASE}/", timeout=30)
+
+        if debug:
+            print(f"  Debug: Initial cookies: {session.cookies.get_dict()}")
+
+        # Try to find the actual login endpoint by checking the site
+        # Warzone likely uses a different login mechanism
+        # Let's try posting to common endpoints
+
+        login_endpoints = [
+            "/API/Login",
+            "/Account/Login",
+            "/Login",
+            "/api/login",
+        ]
+
+        login_data = {
+            'email': email,
+            'Email': email,
+            'password': password,
+            'Password': password,
+        }
+
+        for endpoint in login_endpoints:
+            if debug:
+                print(f"  Trying login endpoint: {endpoint}")
+
+            try:
+                response = session.post(
+                    f"{API_BASE}{endpoint}",
+                    data=login_data,
+                    headers={'Content-Type': 'application/x-www-form-urlencoded'},
+                    timeout=30,
+                    allow_redirects=True
+                )
+
+                if debug:
+                    print(f"    Status: {response.status_code}")
+                    print(f"    Cookies after: {session.cookies.get_dict()}")
+
+                # Check if we got authenticated cookies
+                if response.status_code == 200 and session.cookies:
+                    # Verify by trying to access My Games
+                    test = session.get(f"{API_BASE}/MultiPlayer?MyGames=1", timeout=30)
+                    if "Sign In" not in test.text and "GameID=" in test.text:
+                        print("  Authentication successful!")
+                        return session
+
+            except Exception as e:
+                if debug:
+                    print(f"    Error: {e}")
+                continue
+
+        # If standard login doesn't work, try using the API token to establish a web session
+        # Some sites accept API tokens in cookies
+        print("  Standard login failed, trying API token approach...")
+
+        # Get API token
+        token_response = session.post(
+            f"{API_BASE}/API/GetAPIToken",
+            data=f"Email={email}&Password={password}",
+            headers={'Content-Type': 'application/x-www-form-urlencoded'},
+            timeout=30
+        )
+
+        if token_response.status_code == 200:
+            token_data = token_response.json()
+            if 'APIToken' in token_data:
+                token = token_data['APIToken']
+
+                # Try setting various cookie combinations
+                session.cookies.set('WarzoneToken', token, domain='.warzone.com', path='/')
+                session.cookies.set('AuthToken', token, domain='.warzone.com', path='/')
+                session.cookies.set('APIToken', token, domain='.warzone.com', path='/')
+                session.cookies.set('Email', email, domain='.warzone.com', path='/')
+
+                if debug:
+                    print(f"  Debug: Set cookies with API token")
+                    print(f"  Debug: Cookies: {session.cookies.get_dict()}")
+
+                # Test authentication
+                test = session.get(f"{API_BASE}/MultiPlayer?MyGames=1", timeout=30)
+
+                if debug:
+                    with open("debug_auth_test.html", "w", encoding="utf-8") as f:
+                        f.write(test.text)
+                    print(f"  Debug: Saved auth test to debug_auth_test.html")
+                    print(f"  Debug: Has 'Sign In': {'Sign In' in test.text}")
+                    print(f"  Debug: Has 'GameID=': {'GameID=' in test.text}")
+
+                if "Sign In" not in test.text or "GameID=" in test.text:
+                    print("  Authentication with API token successful!")
+                    return session
+
+        print("  ERROR: All authentication methods failed")
+        return None
+
+    except Exception as e:
+        print(f"  Error during authentication: {e}")
+        if debug:
+            import traceback
+            traceback.print_exc()
+        return None
+
+
+def scrape_game_ids_with_session(session: requests.Session, max_pages: int = 100, debug: bool = False, existing_ids: set = None) -> list[str]:
+    """Scrape all game IDs from the Past Games page using authenticated session.
+
+    If existing_ids is provided (for incremental updates), stops early when
+    encountering games we already have.
+    """
+    print("Scraping game IDs from Past Games (binary format)...")
     all_game_ids = set()
     page = 0
+    pages_with_all_existing = 0
+
+    per_page = 200  # Max allowed by Warzone
 
     while page < max_pages:
-        url = f"{API_BASE}/MultiPlayer?MyGames=1&Offset={page * 50}"
-        print(f"  Fetching page {page + 1} (offset {page * 50})...", end=" ")
+        offset = page * per_page
+        print(f"  Fetching page {page + 1} (offset {offset})...", end=" ")
 
         try:
-            response = session.get(url, timeout=30)
+            # POST to get hex-encoded binary data
+            form_data = {
+                'Offset': offset,
+                'Sort': 3,
+                'PerPage': per_page
+            }
+            response = session.post(
+                f"{API_BASE}/MultiPlayer/PastGames",
+                data=form_data,
+                timeout=30
+            )
+
             if response.status_code != 200:
                 print(f"HTTP {response.status_code}")
                 break
 
-            # Find all game IDs in the page
-            game_ids = re.findall(r'GameID=(\d+)', response.text)
-            unique_ids = set(game_ids)
+            # Response is hex-encoded binary data
+            try:
+                hex_data = response.text.strip()
+                if not hex_data or len(hex_data) < 10:
+                    print("Empty response (no more games)")
+                    break
 
-            if not unique_ids:
-                print("No more games found")
+                decoded_bytes = bytes.fromhex(hex_data)
+
+                if debug and page == 0:
+                    Path("debug_pastgames_page0.bin").write_bytes(decoded_bytes)
+                    print(f"\nDebug: Saved decoded binary to debug_pastgames_page0.bin")
+
+                # Extract game IDs: scan for 32-bit integers in expected range
+                page_ids = set()
+                for i in range(0, len(decoded_bytes) - 4):
+                    val = struct.unpack('<I', decoded_bytes[i:i+4])[0]
+                    # Game IDs are in the 10M-100M range typically
+                    if 10_000_000 <= val <= 100_000_000:
+                        page_ids.add(str(val))
+
+                if not page_ids:
+                    print("No game IDs found (reached end)")
+                    break
+
+                new_ids = page_ids - all_game_ids
+                all_game_ids.update(page_ids)
+
+                # For incremental updates
+                if existing_ids:
+                    newly_discovered = page_ids - existing_ids
+                    if not newly_discovered:
+                        pages_with_all_existing += 1
+                        print(f"All {len(page_ids)} games already in cache ({pages_with_all_existing} consecutive, {len(all_game_ids)} total)")
+
+                        if pages_with_all_existing >= 3:
+                            print("\n  Stopping - 3 pages of existing games")
+                            break
+                    else:
+                        pages_with_all_existing = 0
+                        print(f"Found {len(newly_discovered)} new + {len(page_ids) - len(newly_discovered)} existing ({len(all_game_ids)} total)")
+                else:
+                    print(f"Found {len(new_ids)} new games ({len(all_game_ids)} total)")
+
+                page += 1
+                time.sleep(RATE_LIMIT_DELAY)
+
+            except ValueError as e:
+                print(f"Hex decode error: {e}")
                 break
-
-            new_ids = unique_ids - all_game_ids
-            if not new_ids:
-                print("No new games (reached end)")
-                break
-
-            all_game_ids.update(unique_ids)
-            print(f"Found {len(new_ids)} new games (total: {len(all_game_ids)})")
-
-            page += 1
-            time.sleep(RATE_LIMIT_DELAY)
 
         except Exception as e:
             print(f"Error: {e}")
+            if debug:
+                import traceback
+                traceback.print_exc()
             break
 
     return list(all_game_ids)
@@ -137,13 +378,16 @@ def scrape_game_ids(session: requests.Session, max_pages: int = 100) -> list[str
 
 def fetch_game(game_id: str, email: str, token: str) -> dict | None:
     """Fetch a single game's data from the Warzone API."""
-    data = f"Email={email}&APIToken={token}"
+    # Use dict for proper URL encoding of special characters in token
+    data = {
+        "Email": email,
+        "APIToken": token
+    }
 
     try:
         response = requests.post(
             f"{API_BASE}/API/GameFeed?GameID={game_id}&GetSettings=true",
             data=data,
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
             timeout=30
         )
 
@@ -188,6 +432,37 @@ def parse_game_data(raw: dict) -> dict | None:
     }
 
 
+def _build_output(games: list) -> dict:
+    """Build output JSON structure with stats."""
+    player_stats = {}
+    for game in games:
+        if game["state"] != "Finished":
+            continue
+
+        for player in game["players"]:
+            name = player["name"]
+            if name not in player_stats:
+                player_stats[name] = {
+                    "name": name,
+                    "wins": 0,
+                    "losses": 0,
+                    "games": 0,
+                }
+
+            player_stats[name]["games"] += 1
+            if player["state"] == "Won":
+                player_stats[name]["wins"] += 1
+            elif player["state"] in ("Eliminated", "SurrenderAccepted", "Booted"):
+                player_stats[name]["losses"] += 1
+
+    return {
+        "fetchedAt": datetime.now().isoformat() + "Z",
+        "totalGames": len(games),
+        "games": games,
+        "playerStats": list(player_stats.values()),
+    }
+
+
 def load_game_ids(source: str) -> list[str]:
     """Load game IDs from a file or comma-separated string."""
     path = Path(source)
@@ -207,17 +482,21 @@ def load_game_ids(source: str) -> list[str]:
 
 
 def main():
+    # Load .env file first
+    load_env()
+
     parser = argparse.ArgumentParser(
         description="Fetch Warzone game data for the stats dashboard"
     )
     parser.add_argument(
         "--email", "-e",
-        required=True,
-        help="Your Warzone account email"
+        default=os.environ.get("WARZONE_EMAIL"),
+        help="Your Warzone account email (or set WARZONE_EMAIL in .env)"
     )
     parser.add_argument(
         "--password", "-p",
-        help="Your Warzone account password (for auto-discovery of game IDs)"
+        default=os.environ.get("WARZONE_PASSWORD"),
+        help="Your Warzone account password (or set WARZONE_PASSWORD in .env)"
     )
     parser.add_argument(
         "--token", "-t",
@@ -246,12 +525,32 @@ def main():
         default=0,
         help="Maximum number of games to fetch (0 = unlimited)"
     )
+    parser.add_argument(
+        "--max-pages",
+        type=int,
+        default=100,
+        help="Maximum number of pages to scrape (default 100, ~5000 games)"
+    )
+    parser.add_argument(
+        "--debug", "-d",
+        action="store_true",
+        help="Enable debug mode (saves HTML responses to files for troubleshooting)"
+    )
+    parser.add_argument(
+        "--merge",
+        action="store_true",
+        help="Merge new games with existing data.json (incremental update)"
+    )
 
     args = parser.parse_args()
 
     # Validate arguments
+    if not args.email:
+        print("Error: Email is required (use --email or set WARZONE_EMAIL in .env)")
+        sys.exit(1)
+
     if not args.password and not args.token:
-        print("Error: You must provide either --password or --token")
+        print("Error: You must provide either --password (or WARZONE_PASSWORD in .env) or --token")
         sys.exit(1)
 
     # Get API token
@@ -262,23 +561,44 @@ def main():
             print("Failed to get API token. Check your credentials.")
             sys.exit(1)
 
+    # Load existing games if merging (do this BEFORE scraping)
+    existing_games = {}
+    existing_ids = set()
+    if args.merge and Path(args.output).exists():
+        print(f"Loading existing data from {args.output}...")
+        try:
+            existing_data = json.loads(Path(args.output).read_text())
+            existing_games = {g["id"]: g for g in existing_data.get("games", [])}
+            existing_ids = set(existing_games.keys())
+            print(f"Found {len(existing_games)} existing games")
+        except Exception as e:
+            print(f"Warning: Could not load existing data: {e}")
+
     # Get game IDs
     game_ids = []
     if args.games:
         game_ids = load_game_ids(args.games)
         print(f"Loaded {len(game_ids)} game IDs from input")
     else:
-        # Auto-discover games by scraping
+        # Auto-discover games by authenticating and scraping
+        print("Auto-discovering games...")
+
         if not args.password:
-            print("Error: --password is required for auto-discovery (or provide --games)")
+            print("ERROR: Password required for auto-discovery (or provide --games file)")
             sys.exit(1)
 
-        session = create_session(args.email, args.password)
+        session = authenticate_and_get_session(args.email, args.password, debug=args.debug)
         if not session:
-            print("Failed to create session")
+            print("ERROR: Could not authenticate with Warzone")
             sys.exit(1)
 
-        game_ids = scrape_game_ids(session)
+        # Pass existing IDs so scraper can stop early if merging
+        game_ids = scrape_game_ids_with_session(
+            session,
+            max_pages=args.max_pages,
+            debug=args.debug,
+            existing_ids=existing_ids if args.merge else None
+        )
         print(f"\nDiscovered {len(game_ids)} total games")
 
     if not game_ids:
@@ -307,8 +627,18 @@ def main():
     games = []
     errors = 0
     skipped = 0
+    skipped_existing = 0
+    save_interval = 50  # Save progress every 50 games
 
     for i, game_id in enumerate(game_ids, 1):
+        # Skip if already have this game
+        if game_id in existing_games:
+            games.append(existing_games[game_id])
+            skipped_existing += 1
+            if i % 10 == 0:  # Only print every 10th to avoid spam
+                print(f"[{i}/{len(game_ids)}] Skipping existing games... ({skipped_existing} skipped so far)")
+            continue
+
         print(f"[{i}/{len(game_ids)}] Game {game_id}...", end=" ")
 
         raw = fetch_game(game_id, args.email, api_token)
@@ -342,6 +672,15 @@ def main():
 
         time.sleep(RATE_LIMIT_DELAY)
 
+        # Incremental save: save progress every N games
+        if i % save_interval == 0:
+            temp_output = _build_output(games)
+            Path(args.output).write_text(json.dumps(temp_output, indent=2))
+            print(f"\n  [Progress saved: {len(games)} games so far]\n")
+
+    if skipped_existing > 0:
+        print(f"\nReused {skipped_existing} existing games from cache")
+
     # Calculate aggregate stats
     print("\nCalculating stats...")
     player_stats = {}
@@ -366,12 +705,7 @@ def main():
                 player_stats[name]["losses"] += 1
 
     # Build output
-    output = {
-        "fetchedAt": datetime.utcnow().isoformat() + "Z",
-        "totalGames": len(games),
-        "games": games,
-        "playerStats": list(player_stats.values()),
-    }
+    output = _build_output(games)
 
     # Write output
     output_path = Path(args.output)

--- a/warzone-stats/fetch-games.py
+++ b/warzone-stats/fetch-games.py
@@ -282,19 +282,19 @@ def authenticate_and_get_session(email: str, password: str, debug: bool = False)
 
 
 def scrape_game_ids_with_session(session: requests.Session, max_pages: int = 100, debug: bool = False, existing_ids: set = None) -> list[str]:
-    """Scrape all game IDs from the Past Games page using authenticated session.
+    """Scrape game IDs from the Past Games page.
 
-    If existing_ids is provided (for incremental updates), stops early when
-    encountering games we already have.
+    With --merge: Fetches first page only, stops if ANY games are already cached.
+    Without --merge: Fetches pages up to max_pages.
     """
     print("Scraping game IDs from Past Games (binary format)...")
     all_game_ids = set()
-    page = 0
-    pages_with_all_existing = 0
-
     per_page = 200  # Max allowed by Warzone
 
-    while page < max_pages:
+    # Simple logic: if merging, just get first page and stop if we have any cached
+    pages_to_fetch = 1 if existing_ids else max_pages
+
+    for page in range(pages_to_fetch):
         offset = page * per_page
         print(f"  Fetching page {page + 1} (offset {offset})...", end=" ")
 
@@ -340,26 +340,20 @@ def scrape_game_ids_with_session(session: requests.Session, max_pages: int = 100
                     print("No game IDs found (reached end)")
                     break
 
-                new_ids = page_ids - all_game_ids
                 all_game_ids.update(page_ids)
 
-                # For incremental updates
+                # For incremental updates: check if we have any cached games
                 if existing_ids:
-                    newly_discovered = page_ids - existing_ids
-                    if not newly_discovered:
-                        pages_with_all_existing += 1
-                        print(f"All {len(page_ids)} games already in cache ({pages_with_all_existing} consecutive, {len(all_game_ids)} total)")
+                    cached_count = len(page_ids & existing_ids)
+                    new_count = len(page_ids - existing_ids)
+                    print(f"Found {new_count} new + {cached_count} cached = {len(page_ids)} total IDs")
 
-                        if pages_with_all_existing >= 3:
-                            print("\n  Stopping - 3 pages of existing games")
-                            break
-                    else:
-                        pages_with_all_existing = 0
-                        print(f"Found {len(newly_discovered)} new + {len(page_ids) - len(newly_discovered)} existing ({len(all_game_ids)} total)")
+                    if cached_count > 0:
+                        print(f"  Found cached games - stopping (incremental update)")
+                        break
                 else:
-                    print(f"Found {len(new_ids)} new games ({len(all_game_ids)} total)")
+                    print(f"Found {len(page_ids)} game IDs")
 
-                page += 1
                 time.sleep(RATE_LIMIT_DELAY)
 
             except ValueError as e:

--- a/warzone-stats/index.html
+++ b/warzone-stats/index.html
@@ -117,9 +117,16 @@
 
             const finishedGames = gamesData.games.filter(g => g.state === 'Finished');
             const avgTurns = finishedGames.length > 0
-                ? Math.round(finishedGames.reduce((sum, g) => sum + g.numberOfTurns, 0) / finishedGames.length)
+                ? Math.round(finishedGames.reduce((sum, g) => sum + parseInt(g.numberOfTurns || 0), 0) / finishedGames.length)
                 : 0;
             document.getElementById('avgTurns').textContent = avgTurns;
+
+            // Update total games to show finished count
+            document.getElementById('totalGames').textContent = finishedGames.length;
+            const inProgress = gamesData.games.filter(g => g.state !== 'Finished').length;
+            if (inProgress > 0) {
+                document.getElementById('totalGames').textContent += ` (${inProgress} in progress)`;
+            }
 
             // Leaderboard
             renderLeaderboard();

--- a/warzone-stats/index.html
+++ b/warzone-stats/index.html
@@ -1,0 +1,319 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Warzone Stats Dashboard</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>Warzone Stats Dashboard</h1>
+            <p class="subtitle">9 Years of Strategic Warfare</p>
+            <p class="last-updated" id="lastUpdated"></p>
+        </header>
+
+        <section class="stats-overview" id="statsOverview">
+            <div class="stat-card">
+                <div class="stat-value" id="totalGames">--</div>
+                <div class="stat-label">Total Games</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-value" id="totalPlayers">--</div>
+                <div class="stat-label">Players</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-value" id="avgTurns">--</div>
+                <div class="stat-label">Avg Turns/Game</div>
+            </div>
+        </section>
+
+        <section class="leaderboard">
+            <h2>Leaderboard</h2>
+            <table id="leaderboardTable">
+                <thead>
+                    <tr>
+                        <th>Rank</th>
+                        <th>Player</th>
+                        <th>Wins</th>
+                        <th>Losses</th>
+                        <th>Games</th>
+                        <th>Win Rate</th>
+                    </tr>
+                </thead>
+                <tbody id="leaderboardBody">
+                </tbody>
+            </table>
+        </section>
+
+        <section class="head-to-head">
+            <h2>Head-to-Head Records</h2>
+            <p class="section-desc">Select a player to see their record against others</p>
+            <div class="h2h-controls">
+                <select id="h2hPlayer">
+                    <option value="">Select a player...</option>
+                </select>
+            </div>
+            <div id="h2hResults" class="h2h-results"></div>
+        </section>
+
+        <section class="games-list">
+            <h2>Game History</h2>
+            <div class="filters">
+                <input type="text" id="searchGames" placeholder="Search games...">
+                <select id="filterPlayer">
+                    <option value="">All players</option>
+                </select>
+                <select id="filterState">
+                    <option value="">All states</option>
+                    <option value="Finished">Finished</option>
+                    <option value="Playing">In Progress</option>
+                </select>
+            </div>
+            <div id="gamesContainer" class="games-container"></div>
+        </section>
+
+        <footer>
+            <p>Data powered by <a href="https://www.warzone.com/wiki/API" target="_blank">Warzone API</a></p>
+        </footer>
+    </div>
+
+    <script>
+        let gamesData = null;
+
+        async function loadData() {
+            try {
+                const response = await fetch('data.json');
+                if (!response.ok) {
+                    throw new Error('Could not load data.json - run fetch-games.py first');
+                }
+                gamesData = await response.json();
+                renderDashboard();
+            } catch (error) {
+                document.querySelector('.container').innerHTML = `
+                    <div class="error">
+                        <h2>No Data Found</h2>
+                        <p>${error.message}</p>
+                        <p>To get started:</p>
+                        <ol>
+                            <li>Get your API token from <a href="https://www.warzone.com/API/GetAPIToken">warzone.com</a></li>
+                            <li>Create a file with your game IDs (one per line)</li>
+                            <li>Run: <code>python fetch-games.py -e your@email.com -t YOUR_TOKEN -g game_ids.txt</code></li>
+                        </ol>
+                    </div>
+                `;
+            }
+        }
+
+        function renderDashboard() {
+            // Update timestamp
+            const date = new Date(gamesData.fetchedAt);
+            document.getElementById('lastUpdated').textContent = `Last updated: ${date.toLocaleDateString()} ${date.toLocaleTimeString()}`;
+
+            // Overview stats
+            document.getElementById('totalGames').textContent = gamesData.totalGames;
+            document.getElementById('totalPlayers').textContent = gamesData.playerStats.length;
+
+            const finishedGames = gamesData.games.filter(g => g.state === 'Finished');
+            const avgTurns = finishedGames.length > 0
+                ? Math.round(finishedGames.reduce((sum, g) => sum + g.numberOfTurns, 0) / finishedGames.length)
+                : 0;
+            document.getElementById('avgTurns').textContent = avgTurns;
+
+            // Leaderboard
+            renderLeaderboard();
+
+            // Populate dropdowns
+            populatePlayerDropdowns();
+
+            // Games list
+            renderGames(gamesData.games);
+
+            // Event listeners
+            setupEventListeners();
+        }
+
+        function renderLeaderboard() {
+            const tbody = document.getElementById('leaderboardBody');
+            const sorted = [...gamesData.playerStats].sort((a, b) => {
+                // Sort by wins, then by win rate
+                if (b.wins !== a.wins) return b.wins - a.wins;
+                const aRate = a.games > 0 ? a.wins / a.games : 0;
+                const bRate = b.games > 0 ? b.wins / b.games : 0;
+                return bRate - aRate;
+            });
+
+            tbody.innerHTML = sorted.map((player, idx) => {
+                const winRate = player.games > 0 ? (player.wins / player.games * 100).toFixed(1) : 0;
+                const rankClass = idx < 3 ? `rank-${idx + 1}` : '';
+                return `
+                    <tr class="${rankClass}">
+                        <td class="rank">${idx + 1}</td>
+                        <td class="player-name">${escapeHtml(player.name)}</td>
+                        <td class="wins">${player.wins}</td>
+                        <td class="losses">${player.losses}</td>
+                        <td>${player.games}</td>
+                        <td>${winRate}%</td>
+                    </tr>
+                `;
+            }).join('');
+        }
+
+        function populatePlayerDropdowns() {
+            const players = gamesData.playerStats.map(p => p.name).sort();
+            const options = players.map(p => `<option value="${escapeHtml(p)}">${escapeHtml(p)}</option>`).join('');
+
+            document.getElementById('h2hPlayer').innerHTML = '<option value="">Select a player...</option>' + options;
+            document.getElementById('filterPlayer').innerHTML = '<option value="">All players</option>' + options;
+        }
+
+        function renderGames(games) {
+            const container = document.getElementById('gamesContainer');
+            const sorted = [...games].sort((a, b) => {
+                // Sort by date, newest first
+                if (a.created && b.created) {
+                    return new Date(b.created) - new Date(a.created);
+                }
+                return b.id - a.id;
+            });
+
+            if (sorted.length === 0) {
+                container.innerHTML = '<p class="no-results">No games found</p>';
+                return;
+            }
+
+            container.innerHTML = sorted.map(game => {
+                const date = game.created ? new Date(game.created).toLocaleDateString() : 'Unknown date';
+                const winners = game.winners.length > 0 ? game.winners.join(', ') : 'N/A';
+                const stateClass = game.state === 'Finished' ? 'finished' : 'in-progress';
+
+                const playersList = game.players.map(p => {
+                    const stateIcon = p.state === 'Won' ? ' &#x1F3C6;' : '';
+                    return `<span class="player-tag ${p.state.toLowerCase()}">${escapeHtml(p.name)}${stateIcon}</span>`;
+                }).join(' ');
+
+                return `
+                    <div class="game-card ${stateClass}">
+                        <div class="game-header">
+                            <a href="https://www.warzone.com/MultiPlayer?GameID=${game.id}" target="_blank" class="game-name">${escapeHtml(game.name)}</a>
+                            <span class="game-date">${date}</span>
+                        </div>
+                        <div class="game-details">
+                            <span class="game-state ${stateClass}">${game.state}</span>
+                            <span class="game-turns">${game.numberOfTurns} turns</span>
+                        </div>
+                        <div class="game-players">${playersList}</div>
+                        ${game.winners.length > 0 ? `<div class="game-winner">Winner: ${escapeHtml(winners)}</div>` : ''}
+                    </div>
+                `;
+            }).join('');
+        }
+
+        function calculateH2H(playerName) {
+            const h2h = {};
+
+            gamesData.games.filter(g => g.state === 'Finished').forEach(game => {
+                const playerInGame = game.players.find(p => p.name.toLowerCase() === playerName.toLowerCase());
+                if (!playerInGame) return;
+
+                const playerWon = playerInGame.state === 'Won';
+
+                game.players.forEach(opponent => {
+                    if (opponent.name.toLowerCase() === playerName.toLowerCase()) return;
+
+                    if (!h2h[opponent.name]) {
+                        h2h[opponent.name] = { wins: 0, losses: 0, games: 0 };
+                    }
+
+                    h2h[opponent.name].games++;
+                    if (playerWon) {
+                        h2h[opponent.name].wins++;
+                    } else if (opponent.state === 'Won') {
+                        h2h[opponent.name].losses++;
+                    }
+                });
+            });
+
+            return h2h;
+        }
+
+        function renderH2H(playerName) {
+            const container = document.getElementById('h2hResults');
+
+            if (!playerName) {
+                container.innerHTML = '';
+                return;
+            }
+
+            const h2h = calculateH2H(playerName);
+            const entries = Object.entries(h2h).sort((a, b) => b[1].games - a[1].games);
+
+            if (entries.length === 0) {
+                container.innerHTML = '<p class="no-results">No head-to-head data found</p>';
+                return;
+            }
+
+            container.innerHTML = `
+                <table class="h2h-table">
+                    <thead>
+                        <tr>
+                            <th>Opponent</th>
+                            <th>Record</th>
+                            <th>Games</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        ${entries.map(([opponent, record]) => {
+                            const recordClass = record.wins > record.losses ? 'positive' : record.wins < record.losses ? 'negative' : 'even';
+                            return `
+                                <tr>
+                                    <td>${escapeHtml(opponent)}</td>
+                                    <td class="${recordClass}">${record.wins} - ${record.losses}</td>
+                                    <td>${record.games}</td>
+                                </tr>
+                            `;
+                        }).join('')}
+                    </tbody>
+                </table>
+            `;
+        }
+
+        function setupEventListeners() {
+            // Head-to-head selector
+            document.getElementById('h2hPlayer').addEventListener('change', (e) => {
+                renderH2H(e.target.value);
+            });
+
+            // Game filters
+            const filterGames = () => {
+                const search = document.getElementById('searchGames').value.toLowerCase();
+                const player = document.getElementById('filterPlayer').value.toLowerCase();
+                const state = document.getElementById('filterState').value;
+
+                const filtered = gamesData.games.filter(game => {
+                    if (search && !game.name.toLowerCase().includes(search)) return false;
+                    if (player && !game.players.some(p => p.name.toLowerCase() === player)) return false;
+                    if (state && game.state !== state) return false;
+                    return true;
+                });
+
+                renderGames(filtered);
+            };
+
+            document.getElementById('searchGames').addEventListener('input', filterGames);
+            document.getElementById('filterPlayer').addEventListener('change', filterGames);
+            document.getElementById('filterState').addEventListener('change', filterGames);
+        }
+
+        function escapeHtml(text) {
+            const div = document.createElement('div');
+            div.textContent = text;
+            return div.innerHTML;
+        }
+
+        // Load data on page load
+        loadData();
+    </script>
+</body>
+</html>

--- a/warzone-stats/index.html
+++ b/warzone-stats/index.html
@@ -4,7 +4,427 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Warzone Stats Dashboard</title>
-    <link rel="stylesheet" href="style.css">
+    <style>* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+:root {
+    --bg-primary: #1a1a2e;
+    --bg-secondary: #16213e;
+    --bg-card: #0f3460;
+    --text-primary: #eee;
+    --text-secondary: #aaa;
+    --accent: #e94560;
+    --accent-secondary: #0f3460;
+    --success: #4ecca3;
+    --warning: #ffc93c;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    line-height: 1.6;
+    min-height: 100vh;
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+/* Header */
+header {
+    text-align: center;
+    padding: 40px 0;
+    border-bottom: 1px solid var(--bg-card);
+    margin-bottom: 30px;
+}
+
+header h1 {
+    font-size: 2.5rem;
+    margin-bottom: 10px;
+    background: linear-gradient(135deg, var(--accent), var(--warning));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+}
+
+.last-updated {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    margin-top: 10px;
+}
+
+/* Stats Overview */
+.stats-overview {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 20px;
+    margin-bottom: 40px;
+}
+
+.stat-card {
+    background: var(--bg-card);
+    padding: 25px;
+    border-radius: 12px;
+    text-align: center;
+    transition: transform 0.2s;
+}
+
+.stat-card:hover {
+    transform: translateY(-3px);
+}
+
+.stat-value {
+    font-size: 2.5rem;
+    font-weight: bold;
+    color: var(--accent);
+}
+
+.stat-label {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    margin-top: 5px;
+}
+
+/* Sections */
+section {
+    margin-bottom: 40px;
+}
+
+section h2 {
+    font-size: 1.5rem;
+    margin-bottom: 20px;
+    padding-bottom: 10px;
+    border-bottom: 2px solid var(--accent);
+    display: inline-block;
+}
+
+.section-desc {
+    color: var(--text-secondary);
+    margin-bottom: 15px;
+}
+
+/* Leaderboard Table */
+table {
+    width: 100%;
+    border-collapse: collapse;
+    background: var(--bg-secondary);
+    border-radius: 12px;
+    overflow: hidden;
+}
+
+th, td {
+    padding: 15px;
+    text-align: left;
+}
+
+th {
+    background: var(--bg-card);
+    font-weight: 600;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    font-size: 0.8rem;
+    letter-spacing: 0.5px;
+}
+
+tr:not(:last-child) {
+    border-bottom: 1px solid var(--bg-card);
+}
+
+tr:hover {
+    background: rgba(233, 69, 96, 0.1);
+}
+
+.rank {
+    font-weight: bold;
+    color: var(--text-secondary);
+}
+
+.rank-1 .rank { color: gold; font-size: 1.2rem; }
+.rank-2 .rank { color: silver; font-size: 1.1rem; }
+.rank-3 .rank { color: #cd7f32; font-size: 1.05rem; }
+
+.player-name {
+    font-weight: 600;
+}
+
+.wins {
+    color: var(--success);
+    font-weight: bold;
+}
+
+.losses {
+    color: var(--accent);
+}
+
+.last-win {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
+/* Head-to-Head */
+.h2h-controls {
+    margin-bottom: 20px;
+}
+
+.h2h-controls select {
+    padding: 12px 20px;
+    font-size: 1rem;
+    border: none;
+    border-radius: 8px;
+    background: var(--bg-card);
+    color: var(--text-primary);
+    cursor: pointer;
+    min-width: 200px;
+}
+
+.h2h-table {
+    max-width: 500px;
+}
+
+.h2h-table .positive {
+    color: var(--success);
+    font-weight: bold;
+}
+
+.h2h-table .negative {
+    color: var(--accent);
+}
+
+.h2h-table .even {
+    color: var(--warning);
+}
+
+/* Filters */
+.filters {
+    display: flex;
+    gap: 15px;
+    margin-bottom: 20px;
+    flex-wrap: wrap;
+}
+
+.filters input,
+.filters select {
+    padding: 12px 15px;
+    font-size: 0.95rem;
+    border: none;
+    border-radius: 8px;
+    background: var(--bg-card);
+    color: var(--text-primary);
+    min-width: 150px;
+}
+
+.filters input {
+    flex: 1;
+    min-width: 200px;
+}
+
+.filters input::placeholder {
+    color: var(--text-secondary);
+}
+
+/* Games List */
+.games-container {
+    display: grid;
+    gap: 15px;
+}
+
+.game-card {
+    background: var(--bg-secondary);
+    border-radius: 12px;
+    padding: 20px;
+    border-left: 4px solid var(--accent);
+    transition: transform 0.2s;
+}
+
+.game-card:hover {
+    transform: translateX(5px);
+}
+
+.game-card.finished {
+    border-left-color: var(--success);
+}
+
+.game-card.in-progress {
+    border-left-color: var(--warning);
+}
+
+.game-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.game-name {
+    font-weight: 600;
+    font-size: 1.1rem;
+    color: var(--text-primary);
+    text-decoration: none;
+}
+
+.game-name:hover {
+    color: var(--accent);
+}
+
+.game-date {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+}
+
+.game-details {
+    display: flex;
+    gap: 15px;
+    margin-bottom: 12px;
+    font-size: 0.9rem;
+}
+
+.game-state {
+    padding: 3px 10px;
+    border-radius: 12px;
+    font-size: 0.8rem;
+    font-weight: 600;
+}
+
+.game-state.finished {
+    background: rgba(78, 204, 163, 0.2);
+    color: var(--success);
+}
+
+.game-state.in-progress {
+    background: rgba(255, 201, 60, 0.2);
+    color: var(--warning);
+}
+
+.game-turns {
+    color: var(--text-secondary);
+}
+
+.game-players {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 10px;
+}
+
+.player-tag {
+    padding: 4px 12px;
+    border-radius: 15px;
+    font-size: 0.85rem;
+    background: var(--bg-card);
+}
+
+.player-tag.won {
+    background: rgba(78, 204, 163, 0.3);
+    color: var(--success);
+}
+
+.player-tag.eliminated {
+    opacity: 0.7;
+}
+
+.game-winner {
+    color: var(--success);
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+/* Footer */
+footer {
+    text-align: center;
+    padding: 30px 0;
+    margin-top: 40px;
+    border-top: 1px solid var(--bg-card);
+    color: var(--text-secondary);
+}
+
+footer a {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+footer a:hover {
+    text-decoration: underline;
+}
+
+/* Error State */
+.error {
+    background: var(--bg-secondary);
+    padding: 40px;
+    border-radius: 12px;
+    text-align: center;
+    margin-top: 50px;
+}
+
+.error h2 {
+    color: var(--accent);
+    margin-bottom: 15px;
+}
+
+.error ol {
+    text-align: left;
+    max-width: 500px;
+    margin: 20px auto;
+}
+
+.error li {
+    margin-bottom: 10px;
+}
+
+.error code {
+    background: var(--bg-card);
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.9rem;
+}
+
+.error a {
+    color: var(--accent);
+}
+
+.no-results {
+    text-align: center;
+    color: var(--text-secondary);
+    padding: 40px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    header h1 {
+        font-size: 1.8rem;
+    }
+
+    .stats-overview {
+        grid-template-columns: repeat(3, 1fr);
+    }
+
+    th, td {
+        padding: 10px 8px;
+        font-size: 0.9rem;
+    }
+
+    .filters {
+        flex-direction: column;
+    }
+
+    .filters input,
+    .filters select {
+        width: 100%;
+    }
+}
+</style>
 </head>
 <body>
     <div class="container">
@@ -40,6 +460,7 @@
                         <th>Losses</th>
                         <th>Games</th>
                         <th>Win Rate</th>
+                        <th>Last Win</th>
                     </tr>
                 </thead>
                 <tbody id="leaderboardBody">
@@ -80,11 +501,7962 @@
     </div>
 
     <script>
+        const EMBEDDED_DATA = {
+  "fetchedAt": "2025-11-30T17:43:51.575748Z",
+  "totalGames": 134,
+  "games": [
+    {
+      "id": "12575368",
+      "name": "Jtaugelli's WarLight game",
+      "state": "Finished",
+      "created": "12/28/2016 02:49:46",
+      "numberOfTurns": "21",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Won",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "13litz_krieg"
+      ],
+      "templateId": "971853"
+    },
+    {
+      "id": "13539475",
+      "name": "tedwaldo's WarLight game",
+      "state": "Finished",
+      "created": "5/25/2017 05:50:56",
+      "numberOfTurns": "21",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Declined",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "ajnard"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "32982956",
+      "name": "Failure is Not an Option",
+      "state": "Finished",
+      "created": "12/23/2022 18:30:55",
+      "numberOfTurns": "70",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Booted",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Booted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "13litz_krieg"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "17442171",
+      "name": "Moriarty's Warzone game",
+      "state": "Finished",
+      "created": "1/2/2019 01:14:18",
+      "numberOfTurns": "23",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Booted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Booted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "tedwaldo"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "18506504",
+      "name": "tedwaldo's Warzone game",
+      "state": "Finished",
+      "created": "4/29/2019 00:20:42",
+      "numberOfTurns": "24",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4766742277",
+          "name": "Kelly0303",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Moriarty"
+      ],
+      "templateId": "1229472"
+    },
+    {
+      "id": "25303638",
+      "name": "The Americas",
+      "state": "Finished",
+      "created": "1/9/2021 02:54:02",
+      "numberOfTurns": "38",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "ajnard"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "28610931",
+      "name": "we <3 dauntless",
+      "state": "Finished",
+      "created": "10/21/2021 16:01:15",
+      "numberOfTurns": "38",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "tedwaldo"
+      ],
+      "templateId": "1421405"
+    },
+    {
+      "id": "21269420",
+      "name": "Wes Jones's Warzone game",
+      "state": "Finished",
+      "created": "3/26/2020 23:55:47",
+      "numberOfTurns": "57",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Moriarty"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "26477484",
+      "name": "dom is the impostor",
+      "state": "Finished",
+      "created": "4/9/2021 14:16:03",
+      "numberOfTurns": "34",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "tedwaldo"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "23033287",
+      "name": "Wes Jones' Warzone game",
+      "state": "Finished",
+      "created": "7/1/2020 21:22:44",
+      "numberOfTurns": "48",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Moriarty"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "13440081",
+      "name": "Moriarty's WarLight game",
+      "state": "Finished",
+      "created": "5/8/2017 17:45:05",
+      "numberOfTurns": "28",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Booted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "tedwaldo"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "40504560",
+      "name": "A Song of Ice and Fire",
+      "state": "Finished",
+      "created": "2/23/2025 16:26:39",
+      "numberOfTurns": "31",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Dauntless"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "33864776",
+      "name": "Mr Gump\u2019s Seven Hump Wump",
+      "state": "Finished",
+      "created": "3/19/2023 18:11:32",
+      "numberOfTurns": "46",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Won",
+          "team": "1"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "2"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "2"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "0"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "3"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Won",
+          "team": "1"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "3"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "SurrenderAccepted",
+          "team": "0"
+        }
+      ],
+      "winners": [
+        "dnathe4th",
+        "KennyPowers"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "12647846",
+      "name": "Jtaugelli's WarLight game",
+      "state": "Finished",
+      "created": "1/7/2017 18:03:59",
+      "numberOfTurns": "21",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "dnathe4th"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "19560480",
+      "name": "tedwaldo's Warzone game",
+      "state": "Finished",
+      "created": "9/4/2019 00:12:16",
+      "numberOfTurns": "40",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4766742277",
+          "name": "Kelly0303",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "tedwaldo"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "15708958",
+      "name": "tedwaldo's WarLight game",
+      "state": "Finished",
+      "created": "5/26/2018 19:53:01",
+      "numberOfTurns": "29",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Declined",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4766742277",
+          "name": "Kelly0303",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Moriarty"
+      ],
+      "templateId": "1149926"
+    },
+    {
+      "id": "40001642",
+      "name": "happy new warzone game",
+      "state": "Finished",
+      "created": "1/1/2025 14:46:00",
+      "numberOfTurns": "43",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "ajnard"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "16737305",
+      "name": "KennyPowers' Warzone game",
+      "state": "Finished",
+      "created": "10/21/2018 05:53:44",
+      "numberOfTurns": "28",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "ajnard"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "15410643",
+      "name": "John\u2019s Warzone game",
+      "state": "Finished",
+      "created": "4/13/2018 04:06:02",
+      "numberOfTurns": "19",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4766742277",
+          "name": "Kelly0303",
+          "state": "RemovedByHost",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "dnathe4th"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "27014930",
+      "name": "dnathe4th's Warzone game",
+      "state": "Finished",
+      "created": "5/23/2021 18:45:40",
+      "numberOfTurns": "67",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "dnathe4th"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "28403697",
+      "name": "kelly0303's warlight game",
+      "state": "Finished",
+      "created": "9/30/2021 13:08:28",
+      "numberOfTurns": "34",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "tedwaldo"
+      ],
+      "templateId": "1394422"
+    },
+    {
+      "id": "26860113",
+      "name": "Let there be light",
+      "state": "Finished",
+      "created": "5/10/2021 15:40:23",
+      "numberOfTurns": "40",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "dnathe4th"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "38380230",
+      "name": "Moriarty: Triple Threat",
+      "state": "Finished",
+      "created": "7/7/2024 15:25:50",
+      "numberOfTurns": "9",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Moriarty"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "40806451",
+      "name": "Dauntless's Warzone game",
+      "state": "Finished",
+      "created": "3/26/2025 00:32:23",
+      "numberOfTurns": "20",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Won",
+          "team": "2"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "2"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "3"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Booted",
+          "team": "0"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "0"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "SurrenderAccepted",
+          "team": "1"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Booted",
+          "team": "1"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "3"
+        }
+      ],
+      "winners": [
+        "dnathe4th",
+        "Moriarty"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "15079937",
+      "name": "Mike's Game",
+      "state": "Finished",
+      "created": "2/24/2018 14:57:59",
+      "numberOfTurns": "38",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4766742277",
+          "name": "Kelly0303",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Jtaugelli"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "13868744",
+      "name": "tedwaldo's WarLight game",
+      "state": "Finished",
+      "created": "7/26/2017 05:08:19",
+      "numberOfTurns": "23",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "tedwaldo"
+      ],
+      "templateId": "1055619"
+    },
+    {
+      "id": "28887592",
+      "name": "the buttfish bonanza",
+      "state": "Finished",
+      "created": "11/18/2021 21:39:30",
+      "numberOfTurns": "39",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "13litz_krieg"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "31402899",
+      "name": "Dauntless's Warzone game",
+      "state": "Finished",
+      "created": "7/14/2022 13:50:28",
+      "numberOfTurns": "40",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "tedwaldo"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "34270654",
+      "name": "dnathe4th's Warzone game",
+      "state": "Finished",
+      "created": "4/30/2023 17:21:28",
+      "numberOfTurns": "28",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Moriarty"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "31876029",
+      "name": "make dat $$$$$$",
+      "state": "Finished",
+      "created": "9/3/2022 17:07:22",
+      "numberOfTurns": "28",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "dnathe4th"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "14031564",
+      "name": "ajnard's WarLight game",
+      "state": "Finished",
+      "created": "8/28/2017 18:21:31",
+      "numberOfTurns": "34",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Dauntless"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "26242767",
+      "name": "KennyPowers's Warzone game",
+      "state": "Finished",
+      "created": "3/21/2021 22:33:47",
+      "numberOfTurns": "55",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "tedwaldo"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "30837539",
+      "name": "Time is ticking",
+      "state": "Finished",
+      "created": "5/18/2022 18:54:43",
+      "numberOfTurns": "30",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Booted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "tedwaldo"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "20105243",
+      "name": "Mike's Warzone game",
+      "state": "Finished",
+      "created": "11/17/2019 04:40:48",
+      "numberOfTurns": "35",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4766742277",
+          "name": "Kelly0303",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "tedwaldo"
+      ],
+      "templateId": "1147645"
+    },
+    {
+      "id": "37475272",
+      "name": "Moriarty\u2019s Illegitimate Victory Game",
+      "state": "Finished",
+      "created": "4/3/2024 14:35:01",
+      "numberOfTurns": "77",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Moriarty"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "36782940",
+      "name": "Let\u2019s all blame the placement",
+      "state": "Finished",
+      "created": "1/20/2024 23:56:20",
+      "numberOfTurns": "56",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Booted",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Booted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "dnathe4th"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "12690267",
+      "name": "Jtaugelli's WarLight game",
+      "state": "Finished",
+      "created": "1/13/2017 17:03:29",
+      "numberOfTurns": "63",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Dauntless"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "14211049",
+      "name": "dnathe4th's WarLight game",
+      "state": "Finished",
+      "created": "10/2/2017 16:26:41",
+      "numberOfTurns": "25",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Won",
+          "team": "0"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "SurrenderAccepted",
+          "team": "1"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "2"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "2"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Won",
+          "team": "0"
+        },
+        {
+          "id": "4766742277",
+          "name": "Kelly0303",
+          "state": "Eliminated",
+          "team": "3"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "1"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "SurrenderAccepted",
+          "team": "3"
+        }
+      ],
+      "winners": [
+        "dnathe4th",
+        "ajnard"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "26678961",
+      "name": "dom's warlight game",
+      "state": "Finished",
+      "created": "4/25/2021 18:57:15",
+      "numberOfTurns": "35",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Moriarty"
+      ],
+      "templateId": "1394422"
+    },
+    {
+      "id": "42153983",
+      "name": "Spy vs Spy: RPG edition",
+      "state": "Finished",
+      "created": "8/30/2025 16:17:18",
+      "numberOfTurns": "52",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Moriarty"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "13112527",
+      "name": "Jtaugelli's WarLight game",
+      "state": "Finished",
+      "created": "3/15/2017 01:42:11",
+      "numberOfTurns": "26",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "ajnard"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "18790986",
+      "name": "Moriarty\u2019s Warzone game",
+      "state": "Finished",
+      "created": "6/1/2019 16:27:45",
+      "numberOfTurns": "17",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "0"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "1"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Eliminated",
+          "team": "0"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Won",
+          "team": "1"
+        },
+        {
+          "id": "4766742277",
+          "name": "Kelly0303",
+          "state": "SurrenderAccepted",
+          "team": "0"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Won",
+          "team": "1"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Won",
+          "team": "1"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "0"
+        }
+      ],
+      "winners": [
+        "Moriarty",
+        "Dauntless",
+        "ajnard",
+        "13litz_krieg"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "12446468",
+      "name": "Jtaugelli's WarLight game",
+      "state": "Finished",
+      "created": "12/7/2016 18:43:32",
+      "numberOfTurns": "31",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Jtaugelli"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "18271029",
+      "name": "KennyPowers's Warzone game",
+      "state": "Finished",
+      "created": "4/1/2019 13:30:18",
+      "numberOfTurns": "42",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4766742277",
+          "name": "Kelly0303",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "tedwaldo"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "13965121",
+      "name": "tedwaldo's WarLight game",
+      "state": "Finished",
+      "created": "8/15/2017 01:59:20",
+      "numberOfTurns": "23",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "ajnard"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "13754450",
+      "name": "tedwaldo's WarLight game",
+      "state": "Finished",
+      "created": "7/3/2017 18:13:39",
+      "numberOfTurns": "18",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Booted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Booted",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "tedwaldo"
+      ],
+      "templateId": "1055619"
+    },
+    {
+      "id": "14697420",
+      "name": "dnathe4th's Warzone game",
+      "state": "Finished",
+      "created": "12/30/2017 01:40:09",
+      "numberOfTurns": "22",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "3"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "3"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Eliminated",
+          "team": "1"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Won",
+          "team": "0"
+        },
+        {
+          "id": "4766742277",
+          "name": "Kelly0303",
+          "state": "Eliminated",
+          "team": "2"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "2"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "1"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "0"
+        }
+      ],
+      "winners": [
+        "Dauntless",
+        "tedwaldo"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "19205083",
+      "name": "dnathe4th's Warzone game",
+      "state": "Finished",
+      "created": "7/29/2019 05:39:58",
+      "numberOfTurns": "42",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "EndedByVote",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "EndedByVote",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "RemovedByHost",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4766742277",
+          "name": "Kelly0303",
+          "state": "RemovedByHost",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "EndedByVote",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "EndedByVote",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "EndedByVote",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "EndedByVote",
+          "team": "None"
+        }
+      ],
+      "winners": [],
+      "templateId": null
+    },
+    {
+      "id": "25660335",
+      "name": "A different title",
+      "state": "Finished",
+      "created": "2/4/2021 23:25:50",
+      "numberOfTurns": "31",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "dnathe4th"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "13202917",
+      "name": "ajnard's WarLight game",
+      "state": "Finished",
+      "created": "3/29/2017 17:14:22",
+      "numberOfTurns": "30",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "-1000",
+          "name": "AI 1",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Dauntless"
+      ],
+      "templateId": "1004420"
+    },
+    {
+      "id": "32249254",
+      "name": "dnathe4th's Warzone game",
+      "state": "Finished",
+      "created": "10/12/2022 20:21:16",
+      "numberOfTurns": "10",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "3"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "0"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Booted",
+          "team": "2"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Won",
+          "team": "1"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "0"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "2"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "1"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "3"
+        }
+      ],
+      "winners": [
+        "ajnard",
+        "tedwaldo"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "13060491",
+      "name": "ajnard's WarLight game",
+      "state": "Finished",
+      "created": "3/7/2017 07:57:05",
+      "numberOfTurns": "28",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Jtaugelli"
+      ],
+      "templateId": "1004420"
+    },
+    {
+      "id": "22107501",
+      "name": "Moriarty's Commerce --May the 1% Thrive",
+      "state": "Finished",
+      "created": "5/7/2020 16:30:04",
+      "numberOfTurns": "73",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Moriarty"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "32620791",
+      "name": "The Return Of The Chat (read rules)",
+      "state": "Finished",
+      "created": "11/17/2022 19:07:53",
+      "numberOfTurns": "38",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Moriarty"
+      ],
+      "templateId": "1471169"
+    },
+    {
+      "id": "12848568",
+      "name": "ajnard's WarLight game",
+      "state": "Finished",
+      "created": "2/4/2017 23:38:07",
+      "numberOfTurns": "46",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Won",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "13litz_krieg"
+      ],
+      "templateId": "990112"
+    },
+    {
+      "id": "35975447",
+      "name": "ajnard's Warzone game",
+      "state": "Finished",
+      "created": "10/25/2023 03:54:20",
+      "numberOfTurns": "23",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Booted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Dauntless"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "12376829",
+      "name": "Gladiator",
+      "state": "Finished",
+      "created": "11/26/2016 19:27:49",
+      "numberOfTurns": "32",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Won",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "13litz_krieg"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "41090791",
+      "name": "dnathe4th's Warzone game",
+      "state": "Finished",
+      "created": "4/26/2025 02:48:19",
+      "numberOfTurns": "73",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Moriarty"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "38992978",
+      "name": "Return of the Mack",
+      "state": "Finished",
+      "created": "9/12/2024 00:56:09",
+      "numberOfTurns": "44",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "tedwaldo"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "16095369",
+      "name": "ajnard's Warzone game",
+      "state": "Finished",
+      "created": "7/26/2018 22:36:57",
+      "numberOfTurns": "35",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "4766742277",
+          "name": "Kelly0303",
+          "state": "RemovedByHost",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Dauntless"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "27553352",
+      "name": "dnathe4th's Warzone game",
+      "state": "Finished",
+      "created": "7/7/2021 16:55:58",
+      "numberOfTurns": "31",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "RemovedByHost",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Moriarty"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "35030161",
+      "name": "Moriarty\u2019s",
+      "state": "Finished",
+      "created": "7/18/2023 20:29:39",
+      "numberOfTurns": "42",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Booted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "tedwaldo"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "36591373",
+      "name": "ajnard's Warzone game",
+      "state": "Finished",
+      "created": "12/30/2023 19:52:54",
+      "numberOfTurns": "23",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "3"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "2"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "1"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "3"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "1"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Won",
+          "team": "2"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "SurrenderAccepted",
+          "team": "0"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "0"
+        }
+      ],
+      "winners": [
+        "Moriarty",
+        "KennyPowers"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "12594300",
+      "name": "Jtaugelli's WarLight game",
+      "state": "Finished",
+      "created": "12/30/2016 23:26:54",
+      "numberOfTurns": "31",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Won",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "13litz_krieg"
+      ],
+      "templateId": "973101"
+    },
+    {
+      "id": "13802764",
+      "name": "tedwaldo's WarLight game",
+      "state": "Finished",
+      "created": "7/13/2017 04:24:20",
+      "numberOfTurns": "29",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Booted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Booted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "tedwaldo"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "20805636",
+      "name": "tedwaldo's WarLight game",
+      "state": "Finished",
+      "created": "2/11/2020 20:53:45",
+      "numberOfTurns": "40",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "1"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "0"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Eliminated",
+          "team": "3"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "2"
+        },
+        {
+          "id": "4766742277",
+          "name": "Kelly0303",
+          "state": "Eliminated",
+          "team": "3"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Won",
+          "team": "0"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "4"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "SurrenderAccepted",
+          "team": "1"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "SurrenderAccepted",
+          "team": "2"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "4"
+        }
+      ],
+      "winners": [
+        "Moriarty",
+        "ajnard"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "15945903",
+      "name": "Moriarty's WarLight game",
+      "state": "Finished",
+      "created": "7/3/2018 11:43:07",
+      "numberOfTurns": "28",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4766742277",
+          "name": "Kelly0303",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "ajnard"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "21024374",
+      "name": "ajnard's Warzone game",
+      "state": "Finished",
+      "created": "3/8/2020 05:04:32",
+      "numberOfTurns": "38",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Won",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Wes Jones"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "14549232",
+      "name": "tedwaldo's WarLight game",
+      "state": "Finished",
+      "created": "12/6/2017 05:50:37",
+      "numberOfTurns": "32",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Won",
+          "team": "3"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "0"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "SurrenderAccepted",
+          "team": "2"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "1"
+        },
+        {
+          "id": "4766742277",
+          "name": "Kelly0303",
+          "state": "Eliminated",
+          "team": "0"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "2"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "1"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "3"
+        }
+      ],
+      "winners": [
+        "dnathe4th",
+        "tedwaldo"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "32041333",
+      "name": "dnathe4th's Warzone game STARVATION",
+      "state": "Finished",
+      "created": "9/21/2022 16:21:35",
+      "numberOfTurns": "36",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Booted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "dnathe4th"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "12944974",
+      "name": "13litz_krieg's WarLight game",
+      "state": "Finished",
+      "created": "2/18/2017 21:35:57",
+      "numberOfTurns": "51",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "ajnard"
+      ],
+      "templateId": "967550"
+    },
+    {
+      "id": "18908269",
+      "name": "13litz_krieg's Warzone game",
+      "state": "Finished",
+      "created": "6/17/2019 01:41:17",
+      "numberOfTurns": "63",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4766742277",
+          "name": "Kelly0303",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "dnathe4th"
+      ],
+      "templateId": "1239654"
+    },
+    {
+      "id": "38099917",
+      "name": "Moriarty; Double the Pleasure",
+      "state": "Finished",
+      "created": "6/6/2024 11:10:06",
+      "numberOfTurns": "25",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "2"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "3"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "2"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "0"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "1"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "0"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "1"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Won",
+          "team": "3"
+        }
+      ],
+      "winners": [
+        "Moriarty",
+        "Wes Jones"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "12364091",
+      "name": "Jtaugelli's WarLight game",
+      "state": "Finished",
+      "created": "11/24/2016 21:22:01",
+      "numberOfTurns": "62",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "dnathe4th"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "24660369",
+      "name": "Where in the World is Khaleesi?",
+      "state": "Finished",
+      "created": "11/18/2020 00:51:07",
+      "numberOfTurns": "46",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "tedwaldo"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "25079926",
+      "name": "ceas of konquest",
+      "state": "Finished",
+      "created": "12/22/2020 15:09:34",
+      "numberOfTurns": "39",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "13litz_krieg"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "35300574",
+      "name": "hunter\u2019s garden",
+      "state": "Finished",
+      "created": "8/16/2023 12:40:10",
+      "numberOfTurns": "43",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "EndedByVote",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Booted",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "EndedByVote",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [],
+      "templateId": "1229472"
+    },
+    {
+      "id": "13353367",
+      "name": "dnathe4th's WarLight game",
+      "state": "Finished",
+      "created": "4/23/2017 21:59:16",
+      "numberOfTurns": "29",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Booted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Moriarty"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "17764361",
+      "name": "tedwaldo's WarLight game",
+      "state": "Finished",
+      "created": "2/4/2019 04:05:33",
+      "numberOfTurns": "20",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "dnathe4th"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "13660988",
+      "name": "13litz_krieg's WarLight game",
+      "state": "Finished",
+      "created": "6/16/2017 00:35:09",
+      "numberOfTurns": "22",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "tedwaldo"
+      ],
+      "templateId": "967550"
+    },
+    {
+      "id": "37132484",
+      "name": "dnathe4th's Warzone game",
+      "state": "Finished",
+      "created": "2/27/2024 23:40:03",
+      "numberOfTurns": "77",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Moriarty"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "18639865",
+      "name": "Moriarty\u2019s Warzone game",
+      "state": "Finished",
+      "created": "5/14/2019 14:38:44",
+      "numberOfTurns": "21",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "0"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "1"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Eliminated",
+          "team": "0"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Won",
+          "team": "1"
+        },
+        {
+          "id": "4766742277",
+          "name": "Kelly0303",
+          "state": "Eliminated",
+          "team": "0"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Won",
+          "team": "1"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Won",
+          "team": "1"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "0"
+        }
+      ],
+      "winners": [
+        "Moriarty",
+        "Dauntless",
+        "ajnard",
+        "13litz_krieg"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "36441387",
+      "name": "KennyPowers's Warzone game",
+      "state": "Finished",
+      "created": "12/13/2023 21:42:39",
+      "numberOfTurns": "11",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Moriarty"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "17031217",
+      "name": "ajnard's Warzone game",
+      "state": "Finished",
+      "created": "11/20/2018 19:48:03",
+      "numberOfTurns": "31",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Booted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Booted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Booted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Moriarty"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "29412307",
+      "name": "2 v 2 v 2 v 2",
+      "state": "Finished",
+      "created": "1/11/2022 02:01:36",
+      "numberOfTurns": "45",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "0"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "SurrenderAccepted",
+          "team": "3"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "1"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "3"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "0"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Won",
+          "team": "2"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "SurrenderAccepted",
+          "team": "1"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Won",
+          "team": "2"
+        }
+      ],
+      "winners": [
+        "KennyPowers",
+        "Wes Jones"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "35791329",
+      "name": "dnathe4th's Warzone game",
+      "state": "Finished",
+      "created": "10/5/2023 05:09:24",
+      "numberOfTurns": "24",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "EndedByVote",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "EndedByVote",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [],
+      "templateId": null
+    },
+    {
+      "id": "16278228",
+      "name": "Jim's Warzone game",
+      "state": "Finished",
+      "created": "8/22/2018 00:46:22",
+      "numberOfTurns": "29",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "3"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "0"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "SurrenderAccepted",
+          "team": "1"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "3"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Won",
+          "team": "0"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "2"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "1"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "SurrenderAccepted",
+          "team": "2"
+        }
+      ],
+      "winners": [
+        "Moriarty",
+        "ajnard"
+      ],
+      "templateId": "1167836"
+    },
+    {
+      "id": "14117519",
+      "name": "Jim's WarLight game",
+      "state": "Finished",
+      "created": "9/14/2017 23:36:15",
+      "numberOfTurns": "0",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Booted",
+          "team": "0"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "EndedByVote",
+          "team": "0"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Booted",
+          "team": "1"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Booted",
+          "team": "1"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Booted",
+          "team": "0"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Booted",
+          "team": "1"
+        },
+        {
+          "id": "-1000",
+          "name": "AI 1",
+          "state": "EndedByVote",
+          "team": "1"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Booted",
+          "team": "0"
+        }
+      ],
+      "winners": [],
+      "templateId": null
+    },
+    {
+      "id": "13597566",
+      "name": "ajnard's WarLight game",
+      "state": "Finished",
+      "created": "6/4/2017 20:21:10",
+      "numberOfTurns": "28",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Booted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "13litz_krieg"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "23383677",
+      "name": "God of Morrowind's Wrath",
+      "state": "Finished",
+      "created": "7/29/2020 02:57:49",
+      "numberOfTurns": "45",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "tedwaldo"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "12772346",
+      "name": "Jtaugelli's WarLight game",
+      "state": "Finished",
+      "created": "1/25/2017 03:12:22",
+      "numberOfTurns": "28",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "dnathe4th"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "33497056",
+      "name": "A Return to Normalcy",
+      "state": "Finished",
+      "created": "2/11/2023 02:45:06",
+      "numberOfTurns": "30",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Booted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "tedwaldo"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "13328058",
+      "name": "dnathe4th's WarLight game",
+      "state": "Finished",
+      "created": "4/19/2017 16:26:49",
+      "numberOfTurns": "19",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4383532403",
+          "name": "",
+          "state": "RemovedByHost",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "ajnard"
+      ],
+      "templateId": "1024242"
+    },
+    {
+      "id": "25921295",
+      "name": "dnathe4th's Warzone game",
+      "state": "Finished",
+      "created": "2/24/2021 22:42:44",
+      "numberOfTurns": "47",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "RemovedByHost",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "KennyPowers"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "15638744",
+      "name": "Mike's Warzone game",
+      "state": "Finished",
+      "created": "5/16/2018 14:02:19",
+      "numberOfTurns": "17",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4766742277",
+          "name": "Kelly0303",
+          "state": "RemovedByHost",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "tedwaldo"
+      ],
+      "templateId": "1147645"
+    },
+    {
+      "id": "41936294",
+      "name": "I don't remember how to do this",
+      "state": "Finished",
+      "created": "8/3/2025 21:37:41",
+      "numberOfTurns": "36",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Booted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Booted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Booted",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Booted",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Won",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Wes Jones"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "14404277",
+      "name": "tedwaldo's WarLight game",
+      "state": "Finished",
+      "created": "11/8/2017 22:23:53",
+      "numberOfTurns": "25",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4766742277",
+          "name": "Kelly0303",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "dnathe4th"
+      ],
+      "templateId": "1100553"
+    },
+    {
+      "id": "39617288",
+      "name": "tedwaldo\u2019s magical mushroom adventure",
+      "state": "Finished",
+      "created": "11/20/2024 11:51:06",
+      "numberOfTurns": "48",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Booted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "tedwaldo"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "23732905",
+      "name": "kleopatra's konquest",
+      "state": "Finished",
+      "created": "8/27/2020 19:18:39",
+      "numberOfTurns": "39",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Moriarty"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "18008674",
+      "name": "dnathe4th's Warzone game",
+      "state": "Finished",
+      "created": "3/3/2019 02:29:54",
+      "numberOfTurns": "66",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4766742277",
+          "name": "Kelly0303",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "KennyPowers"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "12756951",
+      "name": "Jtaugelli's WarLight game",
+      "state": "Finished",
+      "created": "1/22/2017 22:30:36",
+      "numberOfTurns": "19",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "ajnard"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "22712852",
+      "name": "Moriarty's Second Warzone game",
+      "state": "Finished",
+      "created": "6/12/2020 00:56:16",
+      "numberOfTurns": "31",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Won",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Wes Jones"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "12815583",
+      "name": "dnathe4th's WarLight game",
+      "state": "Finished",
+      "created": "1/31/2017 00:52:03",
+      "numberOfTurns": "23",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "ajnard"
+      ],
+      "templateId": "987652"
+    },
+    {
+      "id": "12620337",
+      "name": "Jtaugelli's WarLight game",
+      "state": "Finished",
+      "created": "1/3/2017 22:28:33",
+      "numberOfTurns": "30",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "dnathe4th"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "27875508",
+      "name": "Moriartyman, Into the Mori-verse",
+      "state": "Finished",
+      "created": "8/9/2021 18:14:30",
+      "numberOfTurns": "56",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "0"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "3"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "1"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Won",
+          "team": "2"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "1"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "3"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "2"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "0"
+        }
+      ],
+      "winners": [
+        "ajnard",
+        "tedwaldo"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "39396866",
+      "name": "AGI is not yet in warzone",
+      "state": "Finished",
+      "created": "10/27/2024 19:05:48",
+      "numberOfTurns": "27",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Booted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Booted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Booted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "tedwaldo"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "16541384",
+      "name": "ajnard's Warzone game",
+      "state": "Finished",
+      "created": "9/27/2018 18:30:32",
+      "numberOfTurns": "40",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "KennyPowers"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "12566982",
+      "name": "Jtaugelli's WarLight game",
+      "state": "Finished",
+      "created": "12/26/2016 19:48:31",
+      "numberOfTurns": "15",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Jtaugelli"
+      ],
+      "templateId": "971333"
+    },
+    {
+      "id": "30458712",
+      "name": "Viva la Revolucion",
+      "state": "Finished",
+      "created": "4/11/2022 20:20:18",
+      "numberOfTurns": "48",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Moriarty"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "38728445",
+      "name": "claude 3.5: sonnet strikes back",
+      "state": "Finished",
+      "created": "8/15/2024 13:04:21",
+      "numberOfTurns": "33",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Booted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "13litz_krieg"
+      ],
+      "templateId": "1229472"
+    },
+    {
+      "id": "13158327",
+      "name": "ajnard's WarLight game",
+      "state": "Finished",
+      "created": "3/22/2017 03:29:20",
+      "numberOfTurns": "26",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "ajnard"
+      ],
+      "templateId": "1004420"
+    },
+    {
+      "id": "35549530",
+      "name": "mortwaldo's warlight game",
+      "state": "Finished",
+      "created": "9/8/2023 15:26:42",
+      "numberOfTurns": "35",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "EndedByVote",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "EndedByVote",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Booted",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [],
+      "templateId": null
+    },
+    {
+      "id": "19724953",
+      "name": "tedwaldo's Warzone game",
+      "state": "Finished",
+      "created": "9/27/2019 14:01:19",
+      "numberOfTurns": "63",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "13litz_krieg"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "20354891",
+      "name": "tedwaldo's Warzone game",
+      "state": "Finished",
+      "created": "12/18/2019 23:18:01",
+      "numberOfTurns": "33",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4766742277",
+          "name": "Kelly0303",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Moriarty"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "14324897",
+      "name": "More  Random Teams!",
+      "state": "Finished",
+      "created": "10/24/2017 20:17:18",
+      "numberOfTurns": "24",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "3"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "2"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Eliminated",
+          "team": "1"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "0"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "3"
+        },
+        {
+          "id": "4766742277",
+          "name": "Kelly0303",
+          "state": "Eliminated",
+          "team": "0"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "1"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "2"
+        }
+      ],
+      "winners": [
+        "Moriarty",
+        "tedwaldo"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "12549383",
+      "name": "Jtaugelli's WarLight game",
+      "state": "Finished",
+      "created": "12/23/2016 17:47:57",
+      "numberOfTurns": "34",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "ajnard"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "14477041",
+      "name": "dnathe4th's Warzone game",
+      "state": "Finished",
+      "created": "11/22/2017 14:45:41",
+      "numberOfTurns": "21",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Won",
+          "team": "2"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "0"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Eliminated",
+          "team": "0"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "1"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "3"
+        },
+        {
+          "id": "4766742277",
+          "name": "Kelly0303",
+          "state": "Eliminated",
+          "team": "3"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "1"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "2"
+        }
+      ],
+      "winners": [
+        "dnathe4th",
+        "tedwaldo"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "36504278",
+      "name": "I Wanta Be The Very Best",
+      "state": "Finished",
+      "created": "12/20/2023 18:42:57",
+      "numberOfTurns": "19",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "ajnard"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "15549785",
+      "name": "dnathe4th's Warzone game",
+      "state": "Finished",
+      "created": "5/3/2018 13:35:45",
+      "numberOfTurns": "27",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4766742277",
+          "name": "Kelly0303",
+          "state": "RemovedByHost",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "13litz_krieg"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "31109677",
+      "name": "make dat $$$",
+      "state": "Finished",
+      "created": "6/14/2022 23:05:07",
+      "numberOfTurns": "43",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Dauntless"
+      ],
+      "templateId": "1453325"
+    },
+    {
+      "id": "29993696",
+      "name": "KennyPowers's Warzone game",
+      "state": "Finished",
+      "created": "2/26/2022 20:23:26",
+      "numberOfTurns": "40",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Won",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Wes Jones"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "14839274",
+      "name": "tedwaldo's Warzone game",
+      "state": "Finished",
+      "created": "1/20/2018 20:42:02",
+      "numberOfTurns": "27",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Booted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4766742277",
+          "name": "Kelly0303",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "13litz_krieg"
+      ],
+      "templateId": "1120788"
+    },
+    {
+      "id": "38453117",
+      "name": "Moriarty 3.5: Back to Our Roots",
+      "state": "Finished",
+      "created": "7/15/2024 18:53:05",
+      "numberOfTurns": "30",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "tedwaldo"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "14120772",
+      "name": "Jim's WarLight game",
+      "state": "Finished",
+      "created": "9/15/2017 16:36:12",
+      "numberOfTurns": "8",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Won",
+          "team": "0"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "0"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "SurrenderAccepted",
+          "team": "1"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "1"
+        },
+        {
+          "id": "4766742277",
+          "name": "Kelly0303",
+          "state": "SurrenderAccepted",
+          "team": "1"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Won",
+          "team": "0"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "1"
+        },
+        {
+          "id": "-1000",
+          "name": "AI 1",
+          "state": "Won",
+          "team": "0"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "RemovedByHost",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "dnathe4th",
+        "Moriarty",
+        "ajnard",
+        "AI 1"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "42753448",
+      "name": "Someone Trade me F*ing Wheat!",
+      "state": "Playing",
+      "created": "11/1/2025 20:38:42",
+      "numberOfTurns": "21",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Playing",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Playing",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Playing",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Playing",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Playing",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Playing",
+          "team": "None"
+        }
+      ],
+      "winners": [],
+      "templateId": null
+    },
+    {
+      "id": "20516517",
+      "name": "Moriarty's game",
+      "state": "Finished",
+      "created": "1/9/2020 05:56:22",
+      "numberOfTurns": "42",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4766742277",
+          "name": "Kelly0303",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "tedwaldo"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "13237861",
+      "name": "Dauntless's WarLight game",
+      "state": "Finished",
+      "created": "4/4/2017 15:45:51",
+      "numberOfTurns": "36",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Won",
+          "team": "0"
+        },
+        {
+          "id": "3976572255",
+          "name": "Jtaugelli",
+          "state": "SurrenderAccepted",
+          "team": "1"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Won",
+          "team": "0"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Won",
+          "team": "0"
+        },
+        {
+          "id": "-1000",
+          "name": "AI 1",
+          "state": "Eliminated",
+          "team": "1"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "1"
+        }
+      ],
+      "winners": [
+        "dnathe4th",
+        "Dauntless",
+        "ajnard"
+      ],
+      "templateId": "1017556"
+    },
+    {
+      "id": "29178505",
+      "name": "The Return of the Private Message",
+      "state": "Finished",
+      "created": "12/18/2021 23:43:06",
+      "numberOfTurns": "34",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "13litz_krieg"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "34855260",
+      "name": "Dauntless's Warzone game",
+      "state": "Finished",
+      "created": "6/30/2023 06:45:33",
+      "numberOfTurns": "23",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Booted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Booted",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Moriarty"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "32403310",
+      "name": "ajnard\u2019s Warzone game",
+      "state": "Finished",
+      "created": "10/27/2022 21:14:30",
+      "numberOfTurns": "24",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Moriarty"
+      ],
+      "templateId": "1229472"
+    },
+    {
+      "id": "34571424",
+      "name": "Moriarty\u2019s the Captain Now",
+      "state": "Finished",
+      "created": "5/31/2023 19:11:37",
+      "numberOfTurns": "34",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Dauntless"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "41678871",
+      "name": "Moriarty\u2019s Warzone game",
+      "state": "Finished",
+      "created": "7/3/2025 23:16:01",
+      "numberOfTurns": "34",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "13litz_krieg"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "24084757",
+      "name": "Moriarty's Dodeathagon",
+      "state": "Finished",
+      "created": "9/28/2020 18:36:12",
+      "numberOfTurns": "53",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Won",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "Wes Jones"
+      ],
+      "templateId": null
+    },
+    {
+      "id": "36196056",
+      "name": "Dauntless's Warzone game",
+      "state": "Finished",
+      "created": "11/17/2023 17:03:48",
+      "numberOfTurns": "35",
+      "players": [
+        {
+          "id": "3776911513",
+          "name": "dnathe4th",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "4366559531",
+          "name": "Moriarty",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2076911344",
+          "name": "Dauntless",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "3976915175",
+          "name": "ajnard",
+          "state": "SurrenderAccepted",
+          "team": "None"
+        },
+        {
+          "id": "8676914864",
+          "name": "13litz_krieg",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "2879094842",
+          "name": "KennyPowers",
+          "state": "Won",
+          "team": "None"
+        },
+        {
+          "id": "4883720522",
+          "name": "tedwaldo",
+          "state": "Eliminated",
+          "team": "None"
+        },
+        {
+          "id": "89106026916",
+          "name": "Wes Jones",
+          "state": "Eliminated",
+          "team": "None"
+        }
+      ],
+      "winners": [
+        "KennyPowers"
+      ],
+      "templateId": null
+    }
+  ],
+  "playerStats": [
+    {
+      "name": "dnathe4th",
+      "wins": 21,
+      "losses": 110,
+      "games": 133
+    },
+    {
+      "name": "Jtaugelli",
+      "wins": 4,
+      "losses": 57,
+      "games": 66
+    },
+    {
+      "name": "Dauntless",
+      "wins": 12,
+      "losses": 121,
+      "games": 133
+    },
+    {
+      "name": "ajnard",
+      "wins": 23,
+      "losses": 107,
+      "games": 133
+    },
+    {
+      "name": "13litz_krieg",
+      "wins": 16,
+      "losses": 115,
+      "games": 133
+    },
+    {
+      "name": "Moriarty",
+      "wins": 31,
+      "losses": 79,
+      "games": 113
+    },
+    {
+      "name": "tedwaldo",
+      "wins": 31,
+      "losses": 75,
+      "games": 109
+    },
+    {
+      "name": "KennyPowers",
+      "wins": 7,
+      "losses": 79,
+      "games": 87
+    },
+    {
+      "name": "Wes Jones",
+      "wins": 7,
+      "losses": 65,
+      "games": 72
+    },
+    {
+      "name": "Kelly0303",
+      "wins": 0,
+      "losses": 22,
+      "games": 27
+    },
+    {
+      "name": "AI 1",
+      "wins": 1,
+      "losses": 2,
+      "games": 4
+    },
+    {
+      "name": "",
+      "wins": 0,
+      "losses": 0,
+      "games": 1
+    }
+  ]
+};
+
         let gamesData = null;
 
         async function loadData() {
             try {
-                const response = await fetch('data.json');
+                // Embedded data
+                const response = { ok: true, json: async () => EMBEDDED_DATA };
                 if (!response.ok) {
                     throw new Error('Could not load data.json - run fetch-games.py first');
                 }
@@ -141,6 +8513,20 @@
             setupEventListeners();
         }
 
+        function findLastWin(playerName) {
+            let lastWinDate = null;
+            gamesData.games.filter(g => g.state === 'Finished').forEach(game => {
+                const player = game.players.find(p => p.name === playerName);
+                if (player && player.state === 'Won' && game.created) {
+                    const gameDate = new Date(game.created);
+                    if (!lastWinDate || gameDate > lastWinDate) {
+                        lastWinDate = gameDate;
+                    }
+                }
+            });
+            return lastWinDate;
+        }
+
         function renderLeaderboard() {
             const tbody = document.getElementById('leaderboardBody');
             const sorted = [...gamesData.playerStats].sort((a, b) => {
@@ -154,6 +8540,12 @@
             tbody.innerHTML = sorted.map((player, idx) => {
                 const winRate = player.games > 0 ? (player.wins / player.games * 100).toFixed(1) : 0;
                 const rankClass = idx < 3 ? `rank-${idx + 1}` : '';
+
+                const lastWin = findLastWin(player.name);
+                const lastWinText = lastWin
+                    ? lastWin.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+                    : 'Never';
+
                 return `
                     <tr class="${rankClass}">
                         <td class="rank">${idx + 1}</td>
@@ -162,6 +8554,7 @@
                         <td class="losses">${player.losses}</td>
                         <td>${player.games}</td>
                         <td>${winRate}%</td>
+                        <td class="last-win">${lastWinText}</td>
                     </tr>
                 `;
             }).join('');

--- a/warzone-stats/index.html.bak
+++ b/warzone-stats/index.html.bak
@@ -167,6 +167,16 @@ tr:hover {
     color: var(--accent);
 }
 
+.last-win {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
+.placements {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
 /* Head-to-Head */
 .h2h-controls {
     margin-bottom: 20px;
@@ -455,6 +465,8 @@ footer a:hover {
                         <th>Losses</th>
                         <th>Games</th>
                         <th>Win Rate</th>
+                        <th>Last Win</th>
+                        <th>Placements</th>
                     </tr>
                 </thead>
                 <tbody id="leaderboardBody">
@@ -496,8 +508,8 @@ footer a:hover {
 
     <script>
         const EMBEDDED_DATA = {
-  "fetchedAt": "2025-11-30T15:57:51.422992Z",
-  "totalGames": 137,
+  "fetchedAt": "2025-11-30T17:43:51.575748Z",
+  "totalGames": 134,
   "games": [
     {
       "id": "12575368",
@@ -2761,37 +2773,6 @@ footer a:hover {
       "templateId": null
     },
     {
-      "id": "13709736",
-      "name": "Rematch: starvation in Rome, army cap 2x income",
-      "state": "Finished",
-      "created": "6/25/2017 00:11:10",
-      "numberOfTurns": "16",
-      "players": [
-        {
-          "id": "3776911513",
-          "name": "dnathe4th",
-          "state": "SurrenderAccepted",
-          "team": "None"
-        },
-        {
-          "id": "3976572255",
-          "name": "Jtaugelli",
-          "state": "Won",
-          "team": "None"
-        },
-        {
-          "id": "3976915175",
-          "name": "ajnard",
-          "state": "RemovedByHost",
-          "team": "None"
-        }
-      ],
-      "winners": [
-        "Jtaugelli"
-      ],
-      "templateId": "1052462"
-    },
-    {
       "id": "26678961",
       "name": "dom's warlight game",
       "state": "Finished",
@@ -3427,65 +3408,6 @@ footer a:hover {
         "dnathe4th"
       ],
       "templateId": null
-    },
-    {
-      "id": "13299682",
-      "name": "dnathe4th's WarLight game",
-      "state": "Finished",
-      "created": "4/14/2017 21:15:37",
-      "numberOfTurns": "19",
-      "players": [
-        {
-          "id": "3776911513",
-          "name": "dnathe4th",
-          "state": "SurrenderAccepted",
-          "team": "None"
-        },
-        {
-          "id": "3976915175",
-          "name": "ajnard",
-          "state": "SurrenderAccepted",
-          "team": "None"
-        },
-        {
-          "id": "-1000",
-          "name": "AI 1",
-          "state": "EndedByVote",
-          "team": "None"
-        },
-        {
-          "id": "-1001",
-          "name": "AI 2",
-          "state": "EndedByVote",
-          "team": "None"
-        },
-        {
-          "id": "-1002",
-          "name": "AI 3",
-          "state": "EndedByVote",
-          "team": "None"
-        },
-        {
-          "id": "-1003",
-          "name": "AI 4",
-          "state": "EndedByVote",
-          "team": "None"
-        },
-        {
-          "id": "-1004",
-          "name": "AI 5",
-          "state": "EndedByVote",
-          "team": "None"
-        },
-        {
-          "id": "-1005",
-          "name": "AI 6",
-          "state": "Eliminated",
-          "team": "None"
-        }
-      ],
-      "winners": [],
-      "templateId": "1022054"
     },
     {
       "id": "13202917",
@@ -4636,31 +4558,6 @@ footer a:hover {
       "winners": [
         "dnathe4th",
         "tedwaldo"
-      ],
-      "templateId": null
-    },
-    {
-      "id": "15855604",
-      "name": "Auto Imperium Romanum LD 1v1 (light fog)",
-      "state": "Finished",
-      "created": "6/18/2018 06:15:11",
-      "numberOfTurns": "19",
-      "players": [
-        {
-          "id": "3776911513",
-          "name": "dnathe4th",
-          "state": "Won",
-          "team": "None"
-        },
-        {
-          "id": "3976915175",
-          "name": "ajnard",
-          "state": "Booted",
-          "team": "None"
-        }
-      ],
-      "winners": [
-        "dnathe4th"
       ],
       "templateId": null
     },
@@ -8487,15 +8384,15 @@ footer a:hover {
   "playerStats": [
     {
       "name": "dnathe4th",
-      "wins": 22,
-      "losses": 112,
-      "games": 136
+      "wins": 21,
+      "losses": 110,
+      "games": 133
     },
     {
       "name": "Jtaugelli",
-      "wins": 5,
+      "wins": 4,
       "losses": 57,
-      "games": 67
+      "games": 66
     },
     {
       "name": "Dauntless",
@@ -8506,8 +8403,8 @@ footer a:hover {
     {
       "name": "ajnard",
       "wins": 23,
-      "losses": 109,
-      "games": 136
+      "losses": 107,
+      "games": 133
     },
     {
       "name": "13litz_krieg",
@@ -8549,37 +8446,7 @@ footer a:hover {
       "name": "AI 1",
       "wins": 1,
       "losses": 2,
-      "games": 5
-    },
-    {
-      "name": "AI 2",
-      "wins": 0,
-      "losses": 0,
-      "games": 1
-    },
-    {
-      "name": "AI 3",
-      "wins": 0,
-      "losses": 0,
-      "games": 1
-    },
-    {
-      "name": "AI 4",
-      "wins": 0,
-      "losses": 0,
-      "games": 1
-    },
-    {
-      "name": "AI 5",
-      "wins": 0,
-      "losses": 0,
-      "games": 1
-    },
-    {
-      "name": "AI 6",
-      "wins": 0,
-      "losses": 1,
-      "games": 1
+      "games": 4
     },
     {
       "name": "",
@@ -8652,8 +8519,48 @@ footer a:hover {
             setupEventListeners();
         }
 
+        function calculateEnhancedStats() {
+            // Calculate placements and last win for each player
+            const playerData = {};
+
+            gamesData.games.filter(g => g.state === 'Finished').forEach(game => {
+                // Sort players by placement (Won first, then others)
+                const sortedPlayers = [...game.players].sort((a, b) => {
+                    if (a.state === 'Won') return -1;
+                    if (b.state === 'Won') return 1;
+                    return 0;
+                });
+
+                sortedPlayers.forEach((player, placement) => {
+                    const name = player.name;
+                    if (!playerData[name]) {
+                        playerData[name] = {
+                            placements: {},
+                            lastWin: null,
+                            totalPlacements: 0
+                        };
+                    }
+
+                    const pos = placement + 1;
+                    playerData[name].placements[pos] = (playerData[name].placements[pos] || 0) + 1;
+                    playerData[name].totalPlacements++;
+
+                    if (player.state === 'Won' && game.created) {
+                        const gameDate = new Date(game.created);
+                        if (!playerData[name].lastWin || gameDate > playerData[name].lastWin) {
+                            playerData[name].lastWin = gameDate;
+                        }
+                    }
+                });
+            });
+
+            return playerData;
+        }
+
         function renderLeaderboard() {
             const tbody = document.getElementById('leaderboardBody');
+            const enhancedStats = calculateEnhancedStats();
+
             const sorted = [...gamesData.playerStats].sort((a, b) => {
                 // Sort by wins, then by win rate
                 if (b.wins !== a.wins) return b.wins - a.wins;
@@ -8665,6 +8572,21 @@ footer a:hover {
             tbody.innerHTML = sorted.map((player, idx) => {
                 const winRate = player.games > 0 ? (player.wins / player.games * 100).toFixed(1) : 0;
                 const rankClass = idx < 3 ? `rank-${idx + 1}` : '';
+
+                const enhanced = enhancedStats[player.name] || {};
+                const lastWin = enhanced.lastWin
+                    ? enhanced.lastWin.toLocaleDateString('en-US', { month: 'short', year: 'numeric' })
+                    : 'Never';
+
+                // Show placement distribution (1st, 2nd, 3rd, Last)
+                const placements = enhanced.placements || {};
+                const totalGames = enhanced.totalPlacements || 0;
+                const first = placements[1] || 0;
+                const last = placements[totalGames] || 0;
+                const placementText = totalGames > 0
+                    ? `1st: ${first}, Last: ${last}`
+                    : '-';
+
                 return `
                     <tr class="${rankClass}">
                         <td class="rank">${idx + 1}</td>
@@ -8673,6 +8595,8 @@ footer a:hover {
                         <td class="losses">${player.losses}</td>
                         <td>${player.games}</td>
                         <td>${winRate}%</td>
+                        <td class="last-win">${lastWin}</td>
+                        <td class="placements">${placementText}</td>
                     </tr>
                 `;
             }).join('');

--- a/warzone-stats/style.css
+++ b/warzone-stats/style.css
@@ -1,0 +1,415 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+:root {
+    --bg-primary: #1a1a2e;
+    --bg-secondary: #16213e;
+    --bg-card: #0f3460;
+    --text-primary: #eee;
+    --text-secondary: #aaa;
+    --accent: #e94560;
+    --accent-secondary: #0f3460;
+    --success: #4ecca3;
+    --warning: #ffc93c;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    line-height: 1.6;
+    min-height: 100vh;
+}
+
+.container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+/* Header */
+header {
+    text-align: center;
+    padding: 40px 0;
+    border-bottom: 1px solid var(--bg-card);
+    margin-bottom: 30px;
+}
+
+header h1 {
+    font-size: 2.5rem;
+    margin-bottom: 10px;
+    background: linear-gradient(135deg, var(--accent), var(--warning));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+
+.subtitle {
+    color: var(--text-secondary);
+    font-size: 1.1rem;
+}
+
+.last-updated {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    margin-top: 10px;
+}
+
+/* Stats Overview */
+.stats-overview {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 20px;
+    margin-bottom: 40px;
+}
+
+.stat-card {
+    background: var(--bg-card);
+    padding: 25px;
+    border-radius: 12px;
+    text-align: center;
+    transition: transform 0.2s;
+}
+
+.stat-card:hover {
+    transform: translateY(-3px);
+}
+
+.stat-value {
+    font-size: 2.5rem;
+    font-weight: bold;
+    color: var(--accent);
+}
+
+.stat-label {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    margin-top: 5px;
+}
+
+/* Sections */
+section {
+    margin-bottom: 40px;
+}
+
+section h2 {
+    font-size: 1.5rem;
+    margin-bottom: 20px;
+    padding-bottom: 10px;
+    border-bottom: 2px solid var(--accent);
+    display: inline-block;
+}
+
+.section-desc {
+    color: var(--text-secondary);
+    margin-bottom: 15px;
+}
+
+/* Leaderboard Table */
+table {
+    width: 100%;
+    border-collapse: collapse;
+    background: var(--bg-secondary);
+    border-radius: 12px;
+    overflow: hidden;
+}
+
+th, td {
+    padding: 15px;
+    text-align: left;
+}
+
+th {
+    background: var(--bg-card);
+    font-weight: 600;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    font-size: 0.8rem;
+    letter-spacing: 0.5px;
+}
+
+tr:not(:last-child) {
+    border-bottom: 1px solid var(--bg-card);
+}
+
+tr:hover {
+    background: rgba(233, 69, 96, 0.1);
+}
+
+.rank {
+    font-weight: bold;
+    color: var(--text-secondary);
+}
+
+.rank-1 .rank { color: gold; font-size: 1.2rem; }
+.rank-2 .rank { color: silver; font-size: 1.1rem; }
+.rank-3 .rank { color: #cd7f32; font-size: 1.05rem; }
+
+.player-name {
+    font-weight: 600;
+}
+
+.wins {
+    color: var(--success);
+    font-weight: bold;
+}
+
+.losses {
+    color: var(--accent);
+}
+
+/* Head-to-Head */
+.h2h-controls {
+    margin-bottom: 20px;
+}
+
+.h2h-controls select {
+    padding: 12px 20px;
+    font-size: 1rem;
+    border: none;
+    border-radius: 8px;
+    background: var(--bg-card);
+    color: var(--text-primary);
+    cursor: pointer;
+    min-width: 200px;
+}
+
+.h2h-table {
+    max-width: 500px;
+}
+
+.h2h-table .positive {
+    color: var(--success);
+    font-weight: bold;
+}
+
+.h2h-table .negative {
+    color: var(--accent);
+}
+
+.h2h-table .even {
+    color: var(--warning);
+}
+
+/* Filters */
+.filters {
+    display: flex;
+    gap: 15px;
+    margin-bottom: 20px;
+    flex-wrap: wrap;
+}
+
+.filters input,
+.filters select {
+    padding: 12px 15px;
+    font-size: 0.95rem;
+    border: none;
+    border-radius: 8px;
+    background: var(--bg-card);
+    color: var(--text-primary);
+    min-width: 150px;
+}
+
+.filters input {
+    flex: 1;
+    min-width: 200px;
+}
+
+.filters input::placeholder {
+    color: var(--text-secondary);
+}
+
+/* Games List */
+.games-container {
+    display: grid;
+    gap: 15px;
+}
+
+.game-card {
+    background: var(--bg-secondary);
+    border-radius: 12px;
+    padding: 20px;
+    border-left: 4px solid var(--accent);
+    transition: transform 0.2s;
+}
+
+.game-card:hover {
+    transform: translateX(5px);
+}
+
+.game-card.finished {
+    border-left-color: var(--success);
+}
+
+.game-card.in-progress {
+    border-left-color: var(--warning);
+}
+
+.game-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.game-name {
+    font-weight: 600;
+    font-size: 1.1rem;
+    color: var(--text-primary);
+    text-decoration: none;
+}
+
+.game-name:hover {
+    color: var(--accent);
+}
+
+.game-date {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+}
+
+.game-details {
+    display: flex;
+    gap: 15px;
+    margin-bottom: 12px;
+    font-size: 0.9rem;
+}
+
+.game-state {
+    padding: 3px 10px;
+    border-radius: 12px;
+    font-size: 0.8rem;
+    font-weight: 600;
+}
+
+.game-state.finished {
+    background: rgba(78, 204, 163, 0.2);
+    color: var(--success);
+}
+
+.game-state.in-progress {
+    background: rgba(255, 201, 60, 0.2);
+    color: var(--warning);
+}
+
+.game-turns {
+    color: var(--text-secondary);
+}
+
+.game-players {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 10px;
+}
+
+.player-tag {
+    padding: 4px 12px;
+    border-radius: 15px;
+    font-size: 0.85rem;
+    background: var(--bg-card);
+}
+
+.player-tag.won {
+    background: rgba(78, 204, 163, 0.3);
+    color: var(--success);
+}
+
+.player-tag.eliminated {
+    opacity: 0.7;
+}
+
+.game-winner {
+    color: var(--success);
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+/* Footer */
+footer {
+    text-align: center;
+    padding: 30px 0;
+    margin-top: 40px;
+    border-top: 1px solid var(--bg-card);
+    color: var(--text-secondary);
+}
+
+footer a {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+footer a:hover {
+    text-decoration: underline;
+}
+
+/* Error State */
+.error {
+    background: var(--bg-secondary);
+    padding: 40px;
+    border-radius: 12px;
+    text-align: center;
+    margin-top: 50px;
+}
+
+.error h2 {
+    color: var(--accent);
+    margin-bottom: 15px;
+}
+
+.error ol {
+    text-align: left;
+    max-width: 500px;
+    margin: 20px auto;
+}
+
+.error li {
+    margin-bottom: 10px;
+}
+
+.error code {
+    background: var(--bg-card);
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 0.9rem;
+}
+
+.error a {
+    color: var(--accent);
+}
+
+.no-results {
+    text-align: center;
+    color: var(--text-secondary);
+    padding: 40px;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    header h1 {
+        font-size: 1.8rem;
+    }
+
+    .stats-overview {
+        grid-template-columns: repeat(3, 1fr);
+    }
+
+    th, td {
+        padding: 10px 8px;
+        font-size: 0.9rem;
+    }
+
+    .filters {
+        flex-direction: column;
+    }
+
+    .filters input,
+    .filters select {
+        width: 100%;
+    }
+}

--- a/warzone-stats/style.css
+++ b/warzone-stats/style.css
@@ -161,6 +161,11 @@ tr:hover {
     color: var(--accent);
 }
 
+.last-win {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+}
+
 /* Head-to-Head */
 .h2h-controls {
     margin-bottom: 20px;


### PR DESCRIPTION
- Python script to fetch game data from Warzone API with auto-discovery of game IDs via login or manual game ID input
- Static HTML dashboard with leaderboard, head-to-head records, and game history
- Filter options for players and game states
- Sample data.json for testing the dashboard